### PR TITLE
Fix transparency in texture viewer appearing as black

### DIFF
--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -938,7 +938,7 @@ namespace FFXIV_TexTools.ViewModels
                     Width = texData.Width
                 };
 
-                ImageEffect = new ColorChannels
+                _imageEffect = new ColorChannels
                 {
                     Channel = new System.Windows.Media.Media3D.Point4D(1.0f, 1.0f, 1.0f, 0.0f)
                 };
@@ -996,7 +996,7 @@ namespace FFXIV_TexTools.ViewModels
                     IsColorSet = true
                 };
 
-                ImageEffect = new ColorChannels
+                _imageEffect = new ColorChannels
                 {
                     Channel = new System.Windows.Media.Media3D.Point4D(1.0f, 1.0f, 1.0f, 0.0f)
                 };
@@ -1150,7 +1150,13 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         public ColorChannels ImageEffect
         {
-            get => _imageEffect;
+            get
+            {
+                if (this.RedChecked && this.GreenChecked && this.BlueChecked && this.AlphaChecked)
+                    return null;
+
+                return _imageEffect;
+            }
             set
             {
                 _imageEffect = value;
@@ -2143,7 +2149,8 @@ namespace FFXIV_TexTools.ViewModels
             var b = BlueChecked  ? 1.0f : 0.0f;
             var a = AlphaChecked ? 1.0f : 0.0f;
 
-            ImageEffect.Channel = new System.Windows.Media.Media3D.Point4D(r, g, b, a);
+            _imageEffect.Channel = new System.Windows.Media.Media3D.Point4D(r, g, b, a);
+            NotifyPropertyChanged(nameof(ImageEffect));
 
             IImageEncoder imageEncoder;
 


### PR DESCRIPTION
![transparency](https://user-images.githubusercontent.com/379714/83933335-f8686b00-a7ea-11ea-95d3-7e8ca24f4343.jpg)

The black appearance of transparent textures was caused by the channel pixel shader (which we don't have source code for) so I just disable that when all channels of a texture are being viewed.