### PR TITLE
Simple mod pack wizard performance improvements

### DIFF
--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml
@@ -10,7 +10,7 @@
         xmlns:input="clr-namespace:System.Windows.Input;assembly=PresentationCore"
         mc:Ignorable="d"
         Title="{Binding Source={x:Static resx:UIStrings.Simple_ModPack_Creator}}" Height="600" Width="800" IsMinButtonEnabled="False" IsMaxRestoreButtonEnabled="False" WindowStartupLocation="CenterOwner">
-    <Grid>
+    <Grid x:Name="ContentArea">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition/>
@@ -63,28 +63,24 @@
                 <Button x:Name="SelectActiveButton" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1" Content="{Binding Source={x:Static resx:UIStrings.Select_Active}}" Click="SelectActiveButton_Click" Margin="5"/>
                 <Button x:Name="ClearSelectedButton" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="2" Content="{Binding Source={x:Static resx:UIStrings.Clear_Selected}}" Click="ClearSelectedButton_Click" Margin="5"/>
             </Grid>
-            <ListView x:Name="ModListView" Grid.Row="1" SelectionChanged="ModListView_SelectionChanged" SelectionMode="Multiple"
-                      BorderBrush="Black" BorderThickness="0,1" AlternationCount="2" GridViewColumnHeader.Click="Header_Click">
-                <ListView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <StackPanel></StackPanel>
-                    </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
+            <ListView Style="{x:Null}" x:Name="ModListView" Grid.Row="1" SelectionChanged="ModListView_SelectionChanged" SelectionMode="Multiple"
+                      BorderBrush="Black" BorderThickness="0,1" AlternationCount="2" GridViewColumnHeader.Click="Header_Click"
+                      ItemsSource="{Binding Entries}">
                 <ListView.View>
                     <GridView x:Name="GridViewCol">
-                        <GridViewColumn Header="_">
+                        <GridViewColumn Width="32">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <CheckBox IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}, Path=IsSelected}"/>
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
-                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Name}}" DisplayMemberBinding="{Binding Name}"/>
-                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Map}}" DisplayMemberBinding="{Binding Map}"/>
-                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Race}}" DisplayMemberBinding="{Binding Race}"/>
-                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Type}}" DisplayMemberBinding="{Binding Type}"/>
-                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Num}}" DisplayMemberBinding="{Binding Num}"/>
-                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Part}}" DisplayMemberBinding="{Binding Part}"/>
+                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Name}}" DisplayMemberBinding="{Binding Name}" Width="250"/>
+                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Map}}" DisplayMemberBinding="{Binding Map}" Width="100"/>
+                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Race}}" DisplayMemberBinding="{Binding Race}" Width="180"/>
+                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Type}}" DisplayMemberBinding="{Binding Type}" Width="50"/>
+                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Num}}" DisplayMemberBinding="{Binding Num}" Width="50"/>
+                        <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Part}}" DisplayMemberBinding="{Binding Part}" Width="50"/>
                         <GridViewColumn Header="{Binding Source={x:Static resx:UIStrings.Active}}" DisplayMemberBinding="{Binding Active}"/>
                     </GridView>
                 </ListView.View>

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
@@ -40,6 +40,7 @@ using xivModdingFramework.Mods.FileTypes;
 using xivModdingFramework.Textures.Enums;
 using ListViewItem = System.Windows.Controls.ListViewItem;
 using SysTimer = System.Timers;
+using AutoUpdaterDotNET;
 
 namespace FFXIV_TexTools.Views
 {
@@ -48,7 +49,6 @@ namespace FFXIV_TexTools.Views
     /// </summary>
     public partial class SimpleModPackCreator
     {
-        private readonly ObservableCollection<SimpleModPackEntries> _simpleDataList = new ObservableCollection<SimpleModPackEntries>();
         private ListSortDirection _lastDirection = ListSortDirection.Ascending;
         private ProgressDialogController _progressController;
         private readonly DirectoryInfo _gameDirectory;
@@ -63,8 +63,9 @@ namespace FFXIV_TexTools.Views
         {
             InitializeComponent();
 
+            this.ContentArea.DataContext = this;
+
             _gameDirectory = new DirectoryInfo(Properties.Settings.Default.FFXIV_Directory);
-            ModListView.ItemsSource = _simpleDataList;
 
             if (searchTimer == null)
             {
@@ -75,7 +76,7 @@ namespace FFXIV_TexTools.Views
             searchTimer.AutoReset = false;
             searchTimer.Elapsed += SearchTimerOnElapsed;
 
-            Initialize();
+            Task.Run(Initialize);
         }
 
         #region Public Properties
@@ -84,6 +85,8 @@ namespace FFXIV_TexTools.Views
         /// The mod pack file name
         /// </summary>
         public string ModPackFileName { get; private set; }
+
+        public ObservableCollection<SimpleModPackEntries> Entries { get; set; } = new ObservableCollection<SimpleModPackEntries>();
 
         #endregion
 
@@ -94,34 +97,27 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         private async void Initialize()
         {
-            ModListView.IsEnabled = false;
-
-            ModSizeLabel.Content = UIStrings.Loading;
+            App.Current.Dispatcher.Invoke(() =>
+            {
+                ModListView.IsEnabled = false;
+                ModSizeLabel.Content = UIStrings.Loading;
+                ModPackAuthor.Text = Settings.Default.Default_Author;
+            });
 
             await MakeSimpleDataList();
 
-            // Resize columns to fit content
-            foreach (var column in GridViewCol.Columns)
+            App.Current.Dispatcher.Invoke(() =>
             {
-                if (double.IsNaN(column.Width))
-                {
-                    column.Width = column.ActualWidth;
-                }
+                CollectionView cv = (CollectionView)CollectionViewSource.GetDefaultView(this.Entries);
+                cv.SortDescriptions.Clear();
+                cv.SortDescriptions.Add(new SortDescription(nameof(SimpleModPackEntries.Name), _lastDirection));
 
-                column.Width = double.NaN;
-            }
+                ModSizeLabel.Content = "0";
+                ModListView.IsEnabled = true;
 
-            var cv = (CollectionView)CollectionViewSource.GetDefaultView(ModListView.ItemsSource);
-            cv.SortDescriptions.Clear();
-            cv.SortDescriptions.Add(new SortDescription(nameof(SimpleModPackEntries.Name), _lastDirection));
-
-            ModSizeLabel.Content = "0";
-            ModListView.IsEnabled = true;
-
-            CollectionView view = (CollectionView)CollectionViewSource.GetDefaultView(ModListView.ItemsSource);
-            view.Filter = NameFilter;
-
-            ModPackAuthor.Text = Settings.Default.Default_Author;
+                CollectionView view = (CollectionView)CollectionViewSource.GetDefaultView(this.Entries);
+                view.Filter = NameFilter;
+            });
         }
         /// <summary>
         /// filtering ModListView
@@ -130,11 +126,12 @@ namespace FFXIV_TexTools.Views
         /// <returns></returns>
         private bool NameFilter(object item)
         {
-            if (String.IsNullOrEmpty(SearchTextBox.Text.Trim())) return true;                
+            if (string.IsNullOrEmpty(SearchTextBox.Text.Trim()))
+                return true;
 
-            var searchTerms = SearchTextBox.Text.Split('|');
+            string[] searchTerms = SearchTextBox.Text.Split('|');
 
-            foreach (var searchTerm in searchTerms)
+            foreach (string searchTerm in searchTerms)
             {
                 if ((item as SimpleModPackEntries).Name.IndexOf(searchTerm.Trim(), StringComparison.OrdinalIgnoreCase) >= 0) return true;
             }
@@ -159,7 +156,7 @@ namespace FFXIV_TexTools.Views
 
         private void UpdateFilter()
         {
-            CollectionViewSource.GetDefaultView(ModListView.ItemsSource).Refresh();
+            CollectionViewSource.GetDefaultView(this.Entries).Refresh();
         }
 
         /// <summary>
@@ -168,98 +165,54 @@ namespace FFXIV_TexTools.Views
         /// <returns>Task</returns>
         private async Task MakeSimpleDataList()
         {
-            var modListDirectory = new DirectoryInfo(Path.Combine(_gameDirectory.Parent.Parent.FullName, XivStrings.ModlistFilePath));
-            var modding = new Modding(_gameDirectory);
+            DirectoryInfo modListDirectory = new DirectoryInfo(Path.Combine(_gameDirectory.Parent.Parent.FullName, XivStrings.ModlistFilePath));
+            Modding modding = new Modding(_gameDirectory);
 
-            var modList = JsonConvert.DeserializeObject<ModList>(File.ReadAllText(modListDirectory.FullName));
+            ModList modList = JsonConvert.DeserializeObject<ModList>(File.ReadAllText(modListDirectory.FullName));
 
-            var tasks = modList.Mods.Select(mod => AddToList(mod, modding));
+            List<SimpleModPackEntries> entries = new List<SimpleModPackEntries>();
+            foreach (Mod mod in modList.Mods)
+            {
+                SimpleModPackEntries entry = await GetEntry(mod, modding);
+                if (entry == null)
+                    continue;
 
-            await Task.WhenAll(tasks);
+                entries.Add(entry);
+            }
+
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            {
+                foreach (SimpleModPackEntries entry in entries)
+                {
+                    this.Entries.Add(entry);
+                }
+            });
         }
 
-        /// <summary>
-        /// Adds the given mod entry to the simple mod pack data list
-        /// </summary>
-        /// <param name="mod">The mod to be added to the list</param>
-        /// <param name="modding"></param>
-        /// <returns>Task</returns>
-        private async Task AddToList(Mod mod, Modding modding)
+        private async Task<SimpleModPackEntries> GetEntry(Mod mod, Modding modding)
         {
-            if (mod.fullPath.Equals(string.Empty)) return;
+            if (mod.fullPath.Equals(string.Empty))
+                return null;
 
-            var raceTask = GetRace(mod.fullPath);
+            SimpleModPackEntries entry = new SimpleModPackEntries();
 
-            var numberTask = GetNumber(mod.fullPath);
+            entry.Name = mod.name;
+            entry.Category = mod.category;
 
-            var typeTask = GetType(mod.fullPath);
+            XivRace race = GetRace(mod.fullPath);
+            entry.Race = race.GetDisplayName();
 
-            var partTask = GetPart(mod.fullPath);
+            entry.Type = GetType(mod.fullPath);
+            entry.Part = GetPart(mod.fullPath);
+            entry.Num = GetNumber(mod.fullPath);
+            entry.Map = GetMap(mod.fullPath);
 
-            var mapTask = GetMap(mod.fullPath);
+            ////XivModStatus status = await modding.IsModEnabled(mod.fullPath, false);
+            ////entry.Active = status == XivModStatus.Enabled || status == XivModStatus.MatAdd;
 
-            var active = false;
-            var isActiveTask = modding.IsModEnabled(mod.fullPath, false);
+            entry.ModEntry = mod;
 
-            var taskList = new List<Task> { raceTask, numberTask, typeTask, partTask, mapTask, isActiveTask };
-
-            var race = XivRace.All_Races;
-            string number = string.Empty, type = string.Empty, part = string.Empty, map = string.Empty;
-            var isActive = XivModStatus.Disabled;
-
-            while (taskList.Any())
-            {
-                var finished = await Task.WhenAny(taskList);
-
-                if (finished == raceTask)
-                {
-                    taskList.Remove(raceTask);
-                    race = await raceTask;
-                }
-                else if (finished == numberTask)
-                {
-                    taskList.Remove(numberTask);
-                    number = await numberTask;
-                }
-                else if (finished == typeTask)
-                {
-                    taskList.Remove(typeTask);
-                    type = await typeTask;
-                }
-                else if (finished == partTask)
-                {
-                    taskList.Remove(partTask);
-                    part = await partTask;
-                }
-                else if (finished == mapTask)
-                {
-                    taskList.Remove(mapTask);
-                    map = await mapTask;
-                }
-                else if (finished == isActiveTask)
-                {
-                    taskList.Remove(isActiveTask);
-                    isActive = await isActiveTask;
-                }
-            }
-
-            if (isActive == XivModStatus.Enabled || isActive == XivModStatus.MatAdd)
-            {
-                active = true;
-            }
-
-            System.Windows.Application.Current.Dispatcher.Invoke(() => _simpleDataList.Add(new SimpleModPackEntries
-            {
-                Name = mod.name,
-                Category = mod.category,
-                Race = race.GetDisplayName(),
-                Type = type,
-                Part = part,
-                Num = number,
-                Map = map,
-                Active = active,
-                ModEntry = mod,
-            }));
+            return entry;
         }
 
         /// <summary>
@@ -267,51 +220,48 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         /// <param name="modPath">The mod path</param>
         /// <returns>The race as XivRace</returns>
-        private Task<XivRace> GetRace(string modPath)
+        private XivRace GetRace(string modPath)
         {
-            return Task.Run(() =>
-            {
-                var xivRace = XivRace.All_Races;
+            XivRace xivRace = XivRace.All_Races;
 
-                if (modPath.Contains("ui/") || modPath.Contains(".avfx"))
+            if (modPath.Contains("ui/") || modPath.Contains(".avfx"))
+            {
+                xivRace = XivRace.All_Races;
+            }
+            else if (modPath.Contains("monster"))
+            {
+                xivRace = XivRace.Monster;
+            }
+            else if (modPath.Contains("bgcommon"))
+            {
+                xivRace = XivRace.All_Races;
+            }
+            else if (modPath.Contains(".tex") || modPath.Contains(".mdl") || modPath.Contains(".atex"))
+            {
+                if (modPath.Contains("accessory") || modPath.Contains("weapon") || modPath.Contains("/common/"))
                 {
                     xivRace = XivRace.All_Races;
                 }
-                else if (modPath.Contains("monster"))
+                else
                 {
-                    xivRace = XivRace.Monster;
-                }
-                else if (modPath.Contains("bgcommon"))
-                {
-                    xivRace = XivRace.All_Races;
-                }
-                else if (modPath.Contains(".tex") || modPath.Contains(".mdl") || modPath.Contains(".atex"))
-                {
-                    if (modPath.Contains("accessory") || modPath.Contains("weapon") || modPath.Contains("/common/"))
+                    if (modPath.Contains("demihuman"))
                     {
-                        xivRace = XivRace.All_Races;
+                        xivRace = XivRace.DemiHuman;
+                    }
+                    else if (modPath.Contains("/v"))
+                    {
+                        string raceCode = modPath.Substring(modPath.IndexOf("_c") + 2, 4);
+                        xivRace = XivRaces.GetXivRace(raceCode);
                     }
                     else
                     {
-                        if (modPath.Contains("demihuman"))
-                        {
-                            xivRace = XivRace.DemiHuman;
-                        }
-                        else if (modPath.Contains("/v"))
-                        {
-                            var raceCode = modPath.Substring(modPath.IndexOf("_c") + 2, 4);
-                            xivRace = XivRaces.GetXivRace(raceCode);
-                        }
-                        else
-                        {
-                            var raceCode = modPath.Substring(modPath.IndexOf("/c") + 2, 4);
-                            xivRace = XivRaces.GetXivRace(raceCode);
-                        }
+                        string raceCode = modPath.Substring(modPath.IndexOf("/c") + 2, 4);
+                        xivRace = XivRaces.GetXivRace(raceCode);
                     }
                 }
+            }
 
-                return xivRace;
-            });
+            return xivRace;
         }
 
 
@@ -320,67 +270,64 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         /// <param name="modPath">The mod path</param>
         /// <returns>The number</returns>
-        private Task<string> GetNumber(string modPath)
+        private string GetNumber(string modPath)
         {
-            return Task.Run(() =>
+            string number = "-";
+
+            if (modPath.Contains("/human/") && modPath.Contains("/body/"))
             {
-                var number = "-";
+                string subString = modPath.Substring(modPath.LastIndexOf("/b") + 2, 4);
+                number = int.Parse(subString).ToString();
+            }
 
-                if (modPath.Contains("/human/") && modPath.Contains("/body/"))
+            if (modPath.Contains("/face/"))
+            {
+                string subString = modPath.Substring(modPath.LastIndexOf("/f") + 2, 4);
+                number = int.Parse(subString).ToString();
+            }
+
+            if (modPath.Contains("decal_face"))
+            {
+                int length = modPath.LastIndexOf(".") - (modPath.LastIndexOf("_") + 1);
+                string subString = modPath.Substring(modPath.LastIndexOf("_") + 1, length);
+
+                number = int.Parse(subString).ToString();
+            }
+
+            if (modPath.Contains("decal_equip"))
+            {
+                string subString = modPath.Substring(modPath.LastIndexOf("_") + 1, 3);
+
+                try
                 {
-                    var subString = modPath.Substring(modPath.LastIndexOf("/b") + 2, 4);
                     number = int.Parse(subString).ToString();
                 }
-
-                if (modPath.Contains("/face/"))
+                catch
                 {
-                    var subString = modPath.Substring(modPath.LastIndexOf("/f") + 2, 4);
-                    number = int.Parse(subString).ToString();
-                }
-
-                if (modPath.Contains("decal_face"))
-                {
-                    var length = modPath.LastIndexOf(".") - (modPath.LastIndexOf("_") + 1);
-                    var subString = modPath.Substring(modPath.LastIndexOf("_") + 1, length);
-
-                    number = int.Parse(subString).ToString();
-                }
-
-                if (modPath.Contains("decal_equip"))
-                {
-                    var subString = modPath.Substring(modPath.LastIndexOf("_") + 1, 3);
-
-                    try
+                    if (modPath.Contains("stigma"))
                     {
-                        number = int.Parse(subString).ToString();
+                        number = "stigma";
                     }
-                    catch
+                    else
                     {
-                        if (modPath.Contains("stigma"))
-                        {
-                            number = "stigma";
-                        }
-                        else
-                        {
-                            number = "Error";
-                        }
+                        number = "Error";
                     }
                 }
+            }
 
-                if (modPath.Contains("/hair/"))
-                {
-                    var t = modPath.Substring(modPath.LastIndexOf("/h") + 2, 4);
-                    number = int.Parse(t).ToString();
-                }
+            if (modPath.Contains("/hair/"))
+            {
+                string t = modPath.Substring(modPath.LastIndexOf("/h") + 2, 4);
+                number = int.Parse(t).ToString();
+            }
 
-                if (modPath.Contains("/tail/"))
-                {
-                    var t = modPath.Substring(modPath.LastIndexOf("l/t") + 3, 4);
-                    number = int.Parse(t).ToString();
-                }
+            if (modPath.Contains("/tail/"))
+            {
+                string t = modPath.Substring(modPath.LastIndexOf("l/t") + 3, 4);
+                number = int.Parse(t).ToString();
+            }
 
-                return number;
-            });
+            return number;
         }
 
         /// <summary>
@@ -388,52 +335,49 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         /// <param name="modPath">The mod path</param>
         /// <returns>The type</returns>
-        private Task<string> GetType(string modPath)
+        private string GetType(string modPath)
         {
-            return Task.Run(() =>
+            string type = "-";
+
+            if (modPath.Contains(".tex") || modPath.Contains(".mdl") || modPath.Contains(".atex"))
             {
-                var type = "-";
-
-                if (modPath.Contains(".tex") || modPath.Contains(".mdl") || modPath.Contains(".atex"))
+                if (modPath.Contains("demihuman"))
                 {
-                    if (modPath.Contains("demihuman"))
-                    {
-                        type = slotAbr[modPath.Substring(modPath.LastIndexOf("/") + 16, 3)];
-                    }
-
-                    if (modPath.Contains("/face/"))
-                    {
-                        if (modPath.Contains(".tex"))
-                        {
-                            var fileName = Path.GetFileNameWithoutExtension(modPath);
-
-                            type = FaceTypes[fileName.Substring(fileName.IndexOf("_") + 1, 3)];
-                        }
-                    }
-
-                    if (modPath.Contains("/hair/"))
-                    {
-                        if (modPath.Contains(".tex"))
-                        {
-                            var fileName = Path.GetFileNameWithoutExtension(modPath);
-
-                            type = HairTypes[fileName.Substring(fileName.IndexOf("_") + 1, 3)];
-                        }
-                    }
-
-                    if (modPath.Contains("/vfx/"))
-                    {
-                        type = "VFX";
-                    }
-
-                }
-                else if (modPath.Contains(".avfx"))
-                {
-                    type = "AVFX";
+                    type = slotAbr[modPath.Substring(modPath.LastIndexOf("/") + 16, 3)];
                 }
 
-                return type;
-            });
+                if (modPath.Contains("/face/"))
+                {
+                    if (modPath.Contains(".tex"))
+                    {
+                        string fileName = Path.GetFileNameWithoutExtension(modPath);
+
+                        type = FaceTypes[fileName.Substring(fileName.IndexOf("_") + 1, 3)];
+                    }
+                }
+
+                if (modPath.Contains("/hair/"))
+                {
+                    if (modPath.Contains(".tex"))
+                    {
+                        string fileName = Path.GetFileNameWithoutExtension(modPath);
+
+                        type = HairTypes[fileName.Substring(fileName.IndexOf("_") + 1, 3)];
+                    }
+                }
+
+                if (modPath.Contains("/vfx/"))
+                {
+                    type = "VFX";
+                }
+
+            }
+            else if (modPath.Contains(".avfx"))
+            {
+                type = "AVFX";
+            }
+
+            return type;
         }
 
         /// <summary>
@@ -441,33 +385,30 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         /// <param name="modPath">The mod path</param>
         /// <returns>The part</returns>
-        private Task<string> GetPart(string modPath)
+        private string GetPart(string modPath)
         {
-            return Task.Run(() =>
+            string part = "-";
+            string[] parts = new[] { "a", "b", "c", "d", "e", "f" };
+
+            if (modPath.Contains("/equipment/"))
             {
-                var part = "-";
-                var parts = new[] { "a", "b", "c", "d", "e", "f" };
-
-                if (modPath.Contains("/equipment/"))
+                if(modPath.Contains("/texture/"))
                 {
-                    if(modPath.Contains("/texture/"))
+                    part = modPath.Substring(modPath.LastIndexOf("_") - 1, 1);
+                    foreach(string letter in parts)
                     {
-                        part = modPath.Substring(modPath.LastIndexOf("_") - 1, 1);
-                        foreach(var letter in parts)
-                        {
-                            if (part == letter) return part;
-                        }
-                        return "a";
+                        if (part == letter) return part;
                     }
-
-                    if(modPath.Contains("/material/"))
-                    {
-                        return modPath.Substring(modPath.LastIndexOf("_") + 1, 1);
-                    }
+                    return "a";
                 }
 
-                return part;
-            });
+                if(modPath.Contains("/material/"))
+                {
+                    return modPath.Substring(modPath.LastIndexOf("_") + 1, 1);
+                }
+            }
+
+            return part;
         }
 
 
@@ -476,56 +417,53 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         /// <param name="modPath">The mod path</param>
         /// <returns>The map</returns>
-        private Task<string> GetMap(string modPath)
+        private string GetMap(string modPath)
         {
-            return Task.Run(() =>
+            XivTexType xivTexType = XivTexType.Other;
+
+            if (modPath.Contains(".mdl"))
             {
-                var xivTexType = XivTexType.Other;
+                return "3D";
+            }
 
-                if (modPath.Contains(".mdl"))
-                {
-                    return "3D";
-                }
+            if (modPath.Contains(".mtrl"))
+            {
+                return "ColorSet";
+            }
 
-                if (modPath.Contains(".mtrl"))
-                {
-                    return "ColorSet";
-                }
+            if (modPath.Contains("ui/"))
+            {
+                string subString = modPath.Substring(modPath.IndexOf("/") + 1);
+                return subString.Substring(0, subString.IndexOf("/"));
+            }
 
-                if (modPath.Contains("ui/"))
-                {
-                    var subString = modPath.Substring(modPath.IndexOf("/") + 1);
-                    return subString.Substring(0, subString.IndexOf("/"));
-                }
+            if (modPath.Contains("_s.tex") || modPath.Contains("skin_m"))
+            {
+                xivTexType = XivTexType.Specular;
+            }
+            else if (modPath.Contains("_d.tex"))
+            {
+                xivTexType = XivTexType.Diffuse;
+            }
+            else if (modPath.Contains("_n.tex"))
+            {
+                xivTexType = XivTexType.Normal;
+            }
+            else if (modPath.Contains("_m.tex"))
+            {
+                xivTexType = XivTexType.Multi;
+            }
+            else if (modPath.Contains(".atex"))
+            {
+                string atex = Path.GetFileNameWithoutExtension(modPath);
+                return atex.Substring(0, 4);
+            }
+            else if (modPath.Contains("decal"))
+            {
+                xivTexType = XivTexType.Mask;
+            }
 
-                if (modPath.Contains("_s.tex") || modPath.Contains("skin_m"))
-                {
-                    xivTexType = XivTexType.Specular;
-                }
-                else if (modPath.Contains("_d.tex"))
-                {
-                    xivTexType = XivTexType.Diffuse;
-                }
-                else if (modPath.Contains("_n.tex"))
-                {
-                    xivTexType = XivTexType.Normal;
-                }
-                else if (modPath.Contains("_m.tex"))
-                {
-                    xivTexType = XivTexType.Multi;
-                }
-                else if (modPath.Contains(".atex"))
-                {
-                    var atex = Path.GetFileNameWithoutExtension(modPath);
-                    return atex.Substring(0, 4);
-                }
-                else if (modPath.Contains("decal"))
-                {
-                    xivTexType = XivTexType.Mask;
-                }
-
-                return xivTexType.ToString();
-            });
+            return xivTexType.ToString();
         }
 
         /// <summary>
@@ -544,7 +482,7 @@ namespace FFXIV_TexTools.Views
                 _progressController.SetMessage(
                     $"{UIMessages.TTMPGettingData} ({report.current} / {report.total})");
 
-                var value = (double)report.current / (double)report.total;
+                double value = (double)report.current / (double)report.total;
                 _progressController.SetProgress(value);
             }
         }
@@ -571,7 +509,7 @@ namespace FFXIV_TexTools.Views
                 _modSize -= modItem.ModEntry.data.modSize;
             }
 
-            var byteFormatedString = new StringBuilder(32);
+            StringBuilder byteFormatedString = new StringBuilder(32);
             StrFormatByteSize(_modSize, byteFormatedString, byteFormatedString.Capacity);
 
             ModCountLabel.Content = _modCount;
@@ -613,7 +551,7 @@ namespace FFXIV_TexTools.Views
                 }
             }
 
-            var verString = ModPackVersion.Text.Replace("_", "0");
+            string verString = ModPackVersion.Text.Replace("_", "0");
 
             // Replace commas with periods for different culture formats such as FR
             if (verString.Contains(","))
@@ -621,7 +559,7 @@ namespace FFXIV_TexTools.Views
                 verString = verString.Replace(",", ".");
             }
 
-            var versionNumber = Version.Parse(verString);
+            Version versionNumber = Version.Parse(verString);
 
             if (versionNumber.ToString().Equals("0.0.0"))
             {
@@ -656,9 +594,9 @@ namespace FFXIV_TexTools.Views
             _progressController = await this.ShowProgressAsync(UIMessages.ModPackCreationMessage, UIMessages.PleaseStandByMessage);
             ModPackFileName = ModPackName.Text;
 
-            var texToolsModPack = new TTMP(new DirectoryInfo(Properties.Settings.Default.ModPack_Directory), XivStrings.TexTools);
+            TTMP texToolsModPack = new TTMP(new DirectoryInfo(Properties.Settings.Default.ModPack_Directory), XivStrings.TexTools);
 
-            var simpleModPackData = new SimpleModPackData
+            SimpleModPackData simpleModPackData = new SimpleModPackData
             {
                 Name = ModPackName.Text,
                 Author = ModPackAuthor.Text,
@@ -668,7 +606,7 @@ namespace FFXIV_TexTools.Views
 
             foreach (SimpleModPackEntries simpleEntry in ModListView.SelectedItems)
             {
-                var simpleData = new SimpleModData
+                SimpleModData simpleData = new SimpleModData
                 {
                     Name = simpleEntry.Name,
                     Category = simpleEntry.Category,
@@ -682,14 +620,14 @@ namespace FFXIV_TexTools.Views
                 simpleModPackData.SimpleModDataList.Add(simpleData);
             }
 
-            var progressIndicator = new Progress<(int current, int total, string message)>(ReportProgress);
+            Progress<(int current, int total, string message)> progressIndicator = new Progress<(int current, int total, string message)>(ReportProgress);
 
-            var modPackPath = Path.Combine(Properties.Settings.Default.ModPack_Directory, $"{simpleModPackData.Name}.ttmp2");
-            var overwriteModpack = false;
+            string modPackPath = Path.Combine(Properties.Settings.Default.ModPack_Directory, $"{simpleModPackData.Name}.ttmp2");
+            bool overwriteModpack = false;
 
             if (File.Exists(modPackPath))
             {
-                var overwriteDialogResult = FlexibleMessageBox.Show(new Wpf32Window(this), UIMessages.ModPackOverwriteMessage,
+                DialogResult overwriteDialogResult = FlexibleMessageBox.Show(new Wpf32Window(this), UIMessages.ModPackOverwriteMessage,
                                             UIMessages.OverwriteTitle, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
                 if (overwriteDialogResult == System.Windows.Forms.DialogResult.Yes)
                 {
@@ -734,11 +672,11 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         private void SelectActiveButton_Click(object sender, RoutedEventArgs e)
         {
-            for (var i = 0; i < ModListView.Items.Count; i++)
+            for (int i = 0; i < ModListView.Items.Count; i++)
             {
-                var item = (ListViewItem)ModListView.ItemContainerGenerator.ContainerFromIndex(i);
-                var mpi = (SimpleModPackEntries)ModListView.Items[i];
-                var isActive = mpi.Active;
+                ListViewItem item = (ListViewItem)ModListView.ItemContainerGenerator.ContainerFromIndex(i);
+                SimpleModPackEntries mpi = (SimpleModPackEntries)ModListView.Items[i];
+                bool isActive = mpi.Active;
 
                 if (item != null)
                 {
@@ -775,7 +713,7 @@ namespace FFXIV_TexTools.Views
 
             if (e.OriginalSource is GridViewColumnHeader h && !h.Content.ToString().Equals("_"))
             {
-                var cv = (CollectionView)CollectionViewSource.GetDefaultView(ModListView.ItemsSource);
+                CollectionView cv = (CollectionView)CollectionViewSource.GetDefaultView(ModListView.ItemsSource);
                 cv.SortDescriptions.Clear();
                 cv.SortDescriptions.Add(new SortDescription(h.Content.ToString(), _lastDirection));
             }

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
@@ -173,14 +173,14 @@ namespace FFXIV_TexTools.Views
             List<SimpleModPackEntries> entries = new List<SimpleModPackEntries>();
             foreach (Mod mod in modList.Mods)
             {
-                SimpleModPackEntries entry = await GetEntry(mod, modding);
+                SimpleModPackEntries entry = GetEntry(mod, modding);
                 if (entry == null)
                     continue;
 
                 entries.Add(entry);
             }
 
-            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
                 foreach (SimpleModPackEntries entry in entries)
                 {
@@ -189,7 +189,7 @@ namespace FFXIV_TexTools.Views
             });
         }
 
-        private async Task<SimpleModPackEntries> GetEntry(Mod mod, Modding modding)
+        private SimpleModPackEntries GetEntry(Mod mod, Modding modding)
         {
             if (mod.fullPath.Equals(string.Empty))
                 return null;
@@ -206,10 +206,7 @@ namespace FFXIV_TexTools.Views
             entry.Part = GetPart(mod.fullPath);
             entry.Num = GetNumber(mod.fullPath);
             entry.Map = GetMap(mod.fullPath);
-
-            ////XivModStatus status = await modding.IsModEnabled(mod.fullPath, false);
-            ////entry.Active = status == XivModStatus.Enabled || status == XivModStatus.MatAdd;
-
+            entry.Active = mod.enabled || mod.data.modOffset == mod.data.originalOffset;
             entry.ModEntry = mod;
 
             return entry;


### PR DESCRIPTION
this _massively_ reduces the load times of the simple mod pack creator, particularly with large mod lists: previously opening a list of 2205 mods took ~1.5 minutes, now it takes <1 second.

In debug mode this took over 5Gb of Ram, in release the GC was being thrashed causing very poor performance, so I removed basically all of the allocations from the operation.

- Removed all Task.Run calls as they were starving the thread pool
- Don't load the mod list file repeatedly for each mod
- Disable custom theming on the listbox as some custom style was breaking virtualization
- Use Bindings to allow virtualization to lazily load the data
- call the dispatcher.Invoke as few times as possible, as this causes the threads to sync
