### PR TITLE
Add missing 'other' category textures to the modpack wizard.

### DIFF
--- a/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
@@ -716,6 +716,13 @@ namespace FFXIV_TexTools.Views
                         ttp.Type = XivTexType.Other;
                     }
                 }
+                else if (itemPath.Contains(".tex"))
+                {
+                    modCB.Name = $"{XivTexType.Other} ({Path.GetFileNameWithoutExtension(itemPath)})";
+                    modCB.SelectedMod = modItem;
+                    ttp.Type = XivTexType.Other;
+
+                }
 
                 if (modCB.Name != null)
                 {


### PR DESCRIPTION
Tiny fix to enable some textures not showing up in the Modpack Wizard.