### PR TITLE
fix notification animation hanging foever on first use

### DIFF
--- a/FFXIV_TexTools/Controls/FeedbackControl.xaml.cs
+++ b/FFXIV_TexTools/Controls/FeedbackControl.xaml.cs
@@ -56,13 +56,7 @@ namespace FFXIV_TexTools.Controls
 				Storyboard storyboard = this.Resources["FadeIn"] as Storyboard;
 				storyboard.Begin();
 
-				bool complete = false;
-				storyboard.Completed += (s, e) => { complete = true; };
-
-				while (!complete)
-				{
-					await Task.Delay(32);
-				}
+				await Task.Delay(160);
 			}
 		}
 


### PR DESCRIPTION
seems like the storyboard never fires the complete event on the first use in release.
so we'll just wait the known animation time.