### PR TITLE
IItem Refactor.

### DIFF
--- a/FFXIV_TexTools/FFXIV_TexTools.csproj
+++ b/FFXIV_TexTools/FFXIV_TexTools.csproj
@@ -294,6 +294,7 @@
     <Compile Include="ViewModels\ModelSearchViewModel.cs" />
     <Compile Include="ViewModels\ModelViewModel.cs" />
     <Compile Include="ViewModels\ModListViewModel.cs" />
+    <Compile Include="ViewModels\SharedItemsViewModel.cs" />
     <Compile Include="ViewModels\TextureViewModel.cs" />
     <Compile Include="ViewModels\Viewport3DViewModel.cs" />
     <Compile Include="Views\AboutView.xaml.cs">
@@ -374,6 +375,9 @@
     </Compile>
     <Compile Include="Views\ModPack\SimpleModPackImporter.xaml.cs">
       <DependentUpon>SimpleModPackImporter.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SharedItems\SharedItemsView.xaml.cs">
+      <DependentUpon>SharedItemsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Textures\TextureView.xaml.cs">
       <DependentUpon>TextureView.xaml</DependentUpon>
@@ -505,6 +509,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\ModPack\SimpleModPackImporter.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SharedItems\SharedItemsView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/FFXIV_TexTools/MainWindow.xaml
+++ b/FFXIV_TexTools/MainWindow.xaml
@@ -96,6 +96,7 @@
                         <TreeView.ItemContainerStyle>
                             <Style BasedOn="{StaticResource MetroTreeViewItem}" TargetType="{x:Type TreeViewItem}">
                                 <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                                <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
                             </Style>
                         </TreeView.ItemContainerStyle>
                         <TreeView.Resources>
@@ -126,6 +127,9 @@
                 </TabItem>
                 <TabItem x:Name="ModelTabItem" Header="{Binding Source={x:Static resx:UIStrings.Model}}">
                     <views:ModelView/>
+                </TabItem>
+                <TabItem x:Name="SharedItemsTab" Header="Shared Items">
+                    <views:SharedItemsView/>
                 </TabItem>
             </Controls:MetroTabControl>
         </Grid>

--- a/FFXIV_TexTools/MainWindow.xaml
+++ b/FFXIV_TexTools/MainWindow.xaml
@@ -125,10 +125,10 @@
                 <TabItem x:Name="TextureTabItem" Header="{Binding Source={x:Static resx:UIStrings.Textures}}">
                     <views:TextureView/>
                 </TabItem>
-                <TabItem x:Name="ModelTabItem" Header="{Binding Source={x:Static resx:UIStrings.Models}}">
+                <TabItem x:Name="ModelTabItem" Header="{Binding Source={x:Static resx:UIStrings.Models}}" IsEnabled="False" Visibility="Hidden">
                     <views:ModelView/>
                 </TabItem>
-                <TabItem x:Name="SharedItemsTab" Header="{Binding Source={x:Static resx:UIStrings.Variants}}">
+                <TabItem x:Name="SharedItemsTab" Header="{Binding Source={x:Static resx:UIStrings.Variants}}" IsEnabled="False" Visibility="Hidden">
                     <views:SharedItemsView/>
                 </TabItem>
             </Controls:MetroTabControl>

--- a/FFXIV_TexTools/MainWindow.xaml
+++ b/FFXIV_TexTools/MainWindow.xaml
@@ -122,13 +122,13 @@
                 </GridSplitter.Background>
             </GridSplitter>
             <Controls:MetroTabControl x:Name="TabsControl" Grid.Column="2" Controls:TabControlHelper.Underlined="TabPanel">
-                <TabItem x:Name="TextureTabItem" Header="{Binding Source={x:Static resx:UIStrings.Texture}}">
+                <TabItem x:Name="TextureTabItem" Header="{Binding Source={x:Static resx:UIStrings.Textures}}">
                     <views:TextureView/>
                 </TabItem>
-                <TabItem x:Name="ModelTabItem" Header="{Binding Source={x:Static resx:UIStrings.Model}}">
+                <TabItem x:Name="ModelTabItem" Header="{Binding Source={x:Static resx:UIStrings.Models}}">
                     <views:ModelView/>
                 </TabItem>
-                <TabItem x:Name="SharedItemsTab" Header="Shared Items">
+                <TabItem x:Name="SharedItemsTab" Header="{Binding Source={x:Static resx:UIStrings.Variants}}">
                     <views:SharedItemsView/>
                 </TabItem>
             </Controls:MetroTabControl>

--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -377,21 +377,19 @@ namespace FFXIV_TexTools
                 var sharedItemsViewModel = sharedItemsView.DataContext as SharedItemsViewModel;
 
                 await textureViewModel.UpdateTexture(item);
-                await sharedItemsViewModel.SetItem(item, this);
-
-                try
+                var showSharedItems = await sharedItemsViewModel.SetItem(item, this);
+                if(showSharedItems) { 
+                    SharedItemsTab.IsEnabled = true;
+                    SharedItemsTab.Visibility = Visibility.Visible;
+                } else
                 {
-                    var im = (IItemModel)category.Item;
-                    if (im != null)
+                    if(SharedItemsTab.IsSelected)
                     {
-                        SharedItemsTab.IsEnabled = true;
-                    } else
-                    {
-                        SharedItemsTab.IsEnabled = false;
+                        SharedItemsTab.IsSelected = false;
+                        TextureTabItem.IsSelected = true;
                     }
-                } catch(Exception ex)
-                {
                     SharedItemsTab.IsEnabled = false;
+                    SharedItemsTab.Visibility = Visibility.Hidden;
                 }
 
 
@@ -406,10 +404,12 @@ namespace FFXIV_TexTools
                     }
 
                     ModelTabItem.IsEnabled = false;
+                    ModelTabItem.Visibility = Visibility.Hidden;
                 }
                 else
                 {
                     ModelTabItem.IsEnabled = true;
+                    ModelTabItem.Visibility = Visibility.Visible;
 
                     var modelView = ModelTabItem.Content as ModelView;
                     var modelViewModel = modelView.DataContext as ModelViewModel;

--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -150,10 +150,10 @@ namespace FFXIV_TexTools
 
             if(selectedItem?.Item == null) return;
 
-            if (selectedItem.Item.Category.Equals(XivStrings.UI) ||
-                selectedItem.Item.ItemCategory.Equals(XivStrings.Face_Paint) ||
-                selectedItem.Item.ItemCategory.Equals(XivStrings.Equipment_Decals) ||
-                selectedItem.Item.ItemCategory.Equals(XivStrings.Paintings))
+            if (selectedItem.Item.PrimaryCategory.Equals(XivStrings.UI) ||
+                selectedItem.Item.SecondaryCategory.Equals(XivStrings.Face_Paint) ||
+                selectedItem.Item.SecondaryCategory.Equals(XivStrings.Equipment_Decals) ||
+                selectedItem.Item.SecondaryCategory.Equals(XivStrings.Paintings))
             {
                 ItemTreeView.IsEnabled = true;
             }
@@ -269,10 +269,10 @@ namespace FFXIV_TexTools
 
                 await textureViewModel.UpdateTexture(selectedItem.Item);
 
-                if (selectedItem.Item.Category.Equals(XivStrings.UI) ||
-                    selectedItem.Item.ItemCategory.Equals(XivStrings.Face_Paint) ||
-                    selectedItem.Item.ItemCategory.Equals(XivStrings.Equipment_Decals) ||
-                    selectedItem.Item.ItemCategory.Equals(XivStrings.Paintings))
+                if (selectedItem.Item.PrimaryCategory.Equals(XivStrings.UI) ||
+                    selectedItem.Item.SecondaryCategory.Equals(XivStrings.Face_Paint) ||
+                    selectedItem.Item.SecondaryCategory.Equals(XivStrings.Equipment_Decals) ||
+                    selectedItem.Item.SecondaryCategory.Equals(XivStrings.Paintings))
                 {
                     if (TabsControl.SelectedIndex == 1)
                     {

--- a/FFXIV_TexTools/Models/Category.cs
+++ b/FFXIV_TexTools/Models/Category.cs
@@ -26,7 +26,12 @@ namespace FFXIV_TexTools.Models
         /// <summary>
         /// The expanded status of the category
         /// </summary>
-        private bool _isExpanded;
+        private bool _isExpanded = false;
+
+        /// <summary>
+        /// The selected status of the category
+        /// </summary>
+        private bool _isSelected = false;
 
         /// <summary>
         /// The Name of the category
@@ -58,6 +63,19 @@ namespace FFXIV_TexTools.Models
             {
                 _isExpanded = value;
                 NotifyPropertyChanged(nameof(IsExpanded));
+            }
+        }
+
+        /// <summary>
+        /// The selected status of the category
+        /// </summary>
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                _isSelected = value;
+                NotifyPropertyChanged(nameof(IsSelected));
             }
         }
 

--- a/FFXIV_TexTools/Resources/UIStrings.Designer.cs
+++ b/FFXIV_TexTools/Resources/UIStrings.Designer.cs
@@ -1341,6 +1341,15 @@ namespace FFXIV_TexTools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Models.
+        /// </summary>
+        public static string Models {
+            get {
+                return ResourceManager.GetString("Models", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter a Model ID....
         /// </summary>
         public static string ModelSearch_EnterID {
@@ -2389,6 +2398,15 @@ namespace FFXIV_TexTools.Resources {
         public static string Variant {
             get {
                 return ResourceManager.GetString("Variant", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Variants.
+        /// </summary>
+        public static string Variants {
+            get {
+                return ResourceManager.GetString("Variants", resourceCulture);
             }
         }
         

--- a/FFXIV_TexTools/Resources/UIStrings.resx
+++ b/FFXIV_TexTools/Resources/UIStrings.resx
@@ -922,4 +922,10 @@ If you would like to enable this, first import a texture for the selected item.<
   <data name="MaterialEditorHelp" xml:space="preserve">
     <value>Material Editor Help</value>
   </data>
+  <data name="Models" xml:space="preserve">
+    <value>Models</value>
+  </data>
+  <data name="Variants" xml:space="preserve">
+    <value>Variants</value>
+  </data>
 </root>

--- a/FFXIV_TexTools/ViewModels/AdvancedImportViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/AdvancedImportViewModel.cs
@@ -316,12 +316,12 @@ namespace FFXIV_TexTools.ViewModels
                 }
             }
 
-            if (_itemModel.Category.Equals(XivStrings.Gear) && Settings.Default.ForceUV1Quadrant)
+            if (_itemModel.PrimaryCategory.Equals(XivStrings.Gear) && Settings.Default.ForceUV1Quadrant)
             {
                 ForceUV1QuadrantChecked = true;
             }
 
-            if (_itemModel.ItemCategory.Equals(XivStrings.Hair) && Settings.Default.CloneUV1toUV2)
+            if (_itemModel.SecondaryCategory.Equals(XivStrings.Hair) && Settings.Default.CloneUV1toUV2)
             {
                 CloneUV1toUV2Checked = true;
             }

--- a/FFXIV_TexTools/ViewModels/IconSearchViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/IconSearchViewModel.cs
@@ -135,9 +135,9 @@ namespace FFXIV_TexTools.ViewModels
                     var xivUI = new XivUi
                     {
                         Name = Path.GetFileNameWithoutExtension(iconFileString),
-                        Category = XivStrings.UI,
-                        ItemCategory = XivStrings.Icon,
-                        ItemSubCategory = XivStrings.Icon,
+                        PrimaryCategory = XivStrings.UI,
+                        SecondaryCategory = XivStrings.Icon,
+                        TertiaryCategory = XivStrings.Icon,
                         IconNumber = iconInt,
                         DataFile = XivDataFile._06_Ui,
                         UiPath = $"{iconFolderString}/{iconFileString}"
@@ -157,9 +157,9 @@ namespace FFXIV_TexTools.ViewModels
                         var xivUI = new XivUi
                         {
                             Name = Path.GetFileNameWithoutExtension(iconFileString),
-                            Category = XivStrings.UI,
-                            ItemCategory = XivStrings.Icon,
-                            ItemSubCategory = XivStrings.Icon,
+                            PrimaryCategory = XivStrings.UI,
+                            SecondaryCategory = XivStrings.Icon,
+                            TertiaryCategory = XivStrings.Icon,
                             IconNumber = iconInt,
                             DataFile = XivDataFile._06_Ui,
                             UiPath = $"{iconFolderString}/{iconFileString}"

--- a/FFXIV_TexTools/ViewModels/MainViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MainViewModel.cs
@@ -526,7 +526,7 @@ namespace FFXIV_TexTools.ViewModels
 
             foreach (var categoryOrder in _categoryOrderList)
             {
-                var category = new Category { Name = categoryOrder, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>() };
+                var category = new Category { Name = categoryOrder, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>(), ParentCategory = Categories[0] };
                 Categories[0].Categories.Add(category);
                 Categories[0].CategoryList.Add(categoryOrder);
             }
@@ -550,11 +550,11 @@ namespace FFXIV_TexTools.ViewModels
                         where category1.Name == xivGear.SecondaryCategory
                         select category1).FirstOrDefault();
 
-                    cat.Categories.Add(new Category{Name = xivGear.Name, Item = xivGear});
+                    cat.Categories.Add(new Category{Name = xivGear.Name, Item = xivGear, ParentCategory = cat });
                 }
                 else
                 {
-                    var category = new Category {Name = xivGear.SecondaryCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>()};
+                    var category = new Category {Name = xivGear.SecondaryCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>(), ParentCategory = Categories[0]};
                     category.Categories.Add(new Category{Name = xivGear.Name, Item = xivGear});
                     category.CategoryList.Add(xivGear.Name);
                     Categories[0].Categories.Add(category);

--- a/FFXIV_TexTools/ViewModels/MainViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MainViewModel.cs
@@ -544,21 +544,21 @@ namespace FFXIV_TexTools.ViewModels
 
             foreach (var xivGear in gearList)
             {
-                if (Categories[0].CategoryList.Contains(xivGear.ItemCategory))
+                if (Categories[0].CategoryList.Contains(xivGear.SecondaryCategory))
                 {
                     var cat = (from category1 in Categories[0].Categories
-                        where category1.Name == xivGear.ItemCategory
+                        where category1.Name == xivGear.SecondaryCategory
                         select category1).FirstOrDefault();
 
                     cat.Categories.Add(new Category{Name = xivGear.Name, Item = xivGear});
                 }
                 else
                 {
-                    var category = new Category {Name = xivGear.ItemCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>()};
+                    var category = new Category {Name = xivGear.SecondaryCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>()};
                     category.Categories.Add(new Category{Name = xivGear.Name, Item = xivGear});
                     category.CategoryList.Add(xivGear.Name);
                     Categories[0].Categories.Add(category);
-                    Categories[0].CategoryList.Add(xivGear.ItemCategory);
+                    Categories[0].CategoryList.Add(xivGear.SecondaryCategory);
                 }
             }
 
@@ -613,60 +613,60 @@ namespace FFXIV_TexTools.ViewModels
 
             foreach (var xivUi in uiList)
             {
-                if (xivUi.ItemSubCategory != null)
+                if (xivUi.TertiaryCategory != null)
                 {
-                    if (Categories[3].CategoryList.Contains(xivUi.ItemCategory))
+                    if (Categories[3].CategoryList.Contains(xivUi.SecondaryCategory))
                     {
                         var cat = (from category1 in Categories[3].Categories
-                            where category1.Name == xivUi.ItemCategory
+                            where category1.Name == xivUi.SecondaryCategory
                             select category1).FirstOrDefault();
 
-                        if (cat.CategoryList.Contains(xivUi.ItemSubCategory))
+                        if (cat.CategoryList.Contains(xivUi.TertiaryCategory))
                         {
                             var subcat = (from category1 in cat.Categories
-                                where category1.Name == xivUi.ItemSubCategory
+                                where category1.Name == xivUi.TertiaryCategory
                                 select category1).FirstOrDefault();
 
                             subcat.Categories.Add(new Category { Name = xivUi.Name, Item = xivUi });
                         }
                         else
                         {
-                            var subCategory = new Category { Name = xivUi.ItemSubCategory, Categories = new ObservableCollection<Category>() };
+                            var subCategory = new Category { Name = xivUi.TertiaryCategory, Categories = new ObservableCollection<Category>() };
                             subCategory.Categories.Add(new Category { Name = xivUi.Name, Item = xivUi });
 
                             cat.Categories.Add(subCategory);
-                            cat.CategoryList.Add(xivUi.ItemSubCategory);
+                            cat.CategoryList.Add(xivUi.TertiaryCategory);
                         }
                     }
                     else
                     {
-                        var category = new Category { Name = xivUi.ItemCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>()};
-                        var subCategory = new Category { Name = xivUi.ItemSubCategory, Categories = new ObservableCollection<Category>()};
+                        var category = new Category { Name = xivUi.SecondaryCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>()};
+                        var subCategory = new Category { Name = xivUi.TertiaryCategory, Categories = new ObservableCollection<Category>()};
                         subCategory.Categories.Add(new Category { Name = xivUi.Name, Item = xivUi });
                  
                         category.Categories.Add(subCategory);
-                        category.CategoryList.Add(xivUi.ItemSubCategory);
+                        category.CategoryList.Add(xivUi.TertiaryCategory);
 
                         Categories[3].Categories.Add(category);
-                        Categories[3].CategoryList.Add(xivUi.ItemCategory);
+                        Categories[3].CategoryList.Add(xivUi.SecondaryCategory);
                     }
                 }
                 else
                 {
-                    if (Categories[3].CategoryList.Contains(xivUi.ItemCategory))
+                    if (Categories[3].CategoryList.Contains(xivUi.SecondaryCategory))
                     {
                         var cat = (from category1 in Categories[3].Categories
-                            where category1.Name == xivUi.ItemCategory
+                            where category1.Name == xivUi.SecondaryCategory
                             select category1).FirstOrDefault();
 
                         cat.Categories.Add(new Category { Name = xivUi.Name, Item = xivUi });
                     }
                     else
                     {
-                        var category = new Category { Name = xivUi.ItemCategory, Categories = new ObservableCollection<Category>() };
+                        var category = new Category { Name = xivUi.SecondaryCategory, Categories = new ObservableCollection<Category>() };
                         category.Categories.Add(new Category { Name = xivUi.Name, Item = xivUi });
                         Categories[3].Categories.Add(category);
-                        Categories[3].CategoryList.Add(xivUi.ItemCategory);
+                        Categories[3].CategoryList.Add(xivUi.SecondaryCategory);
                     }
                 }
             }
@@ -678,21 +678,21 @@ namespace FFXIV_TexTools.ViewModels
 
             foreach (var xivFurniture in housingList)
             {
-                if (Categories[4].CategoryList.Contains(xivFurniture.ItemCategory))
+                if (Categories[4].CategoryList.Contains(xivFurniture.SecondaryCategory))
                 {
                     var cat = (from category1 in Categories[4].Categories
-                        where category1.Name == xivFurniture.ItemCategory
+                        where category1.Name == xivFurniture.SecondaryCategory
                         select category1).FirstOrDefault();
 
                     cat.Categories.Add(new Category{Name = xivFurniture.Name, Item = xivFurniture});
                 }
                 else
                 {
-                    var category = new Category { Name = xivFurniture.ItemCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>() };
+                    var category = new Category { Name = xivFurniture.SecondaryCategory, Categories = new ObservableCollection<Category>(), CategoryList = new List<string>() };
                     category.Categories.Add(new Category { Name = xivFurniture.Name, Item = xivFurniture });
                     category.CategoryList.Add(xivFurniture.Name);
                     Categories[4].Categories.Add(category);
-                    Categories[4].CategoryList.Add(xivFurniture.ItemCategory);
+                    Categories[4].CategoryList.Add(xivFurniture.SecondaryCategory);
                 }
             }
 

--- a/FFXIV_TexTools/ViewModels/ModConverterViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModConverterViewModel.cs
@@ -116,7 +116,7 @@ namespace FFXIV_TexTools.ViewModels
             if (fromItem != null)
             {
                 var targetItem = ItemList.Single(it => it.Name == TargetItemName);
-                if (XivCategorys.GetDisplayName(fromItem.Category) != XivCategorys.GetDisplayName(targetItem.ItemCategory))
+                if (XivCategories.GetDisplayName(fromItem.Category) != XivCategories.GetDisplayName(targetItem.SecondaryCategory))
                     return;
                 //if ((fromItem as IItemModel).ModelInfo.ModelID == (targetItem as IItemModel).ModelInfo.ModelID)
                 //    return;
@@ -159,9 +159,9 @@ namespace FFXIV_TexTools.ViewModels
                 }
                 else
                 {
-                    var fromCategory = XivCategorys.GetDisplayName(fromItem2.Category);
+                    var fromCategory = XivCategories.GetDisplayName(fromItem2.Category);
                     query = ItemList.Where(
-                        it => it.ItemCategory == fromCategory
+                        it => it.SecondaryCategory == fromCategory
                         && it.Name != fromItem2.Name
                     ).Select(it => it.Name);
                 }
@@ -169,9 +169,9 @@ namespace FFXIV_TexTools.ViewModels
             else
             {
                 query = ItemList.Where(
-                    it => it.ItemCategory == fromItem.ItemCategory
+                    it => it.SecondaryCategory == fromItem.SecondaryCategory
                     &&it.Name!=fromItem.Name
-                    &&(it as IItemModel).ModelInfo.ModelID!= (fromItem as IItemModel).ModelInfo.ModelID
+                    &&(it as IItemModel).ModelInfo.PrimaryID!= (fromItem as IItemModel).ModelInfo.PrimaryID
                 ).Select(it => it.Name);
             }
             foreach (var item in query)
@@ -212,7 +212,7 @@ namespace FFXIV_TexTools.ViewModels
                 var fromId = fromInfo.Id;
                 var fromMdlRace = fromInfo.Race;
 
-                var targetId = $"{fromId[0]}{targetItemModel.ModelInfo.ModelID.ToString().PadLeft(4, '0')}";
+                var targetId = $"{fromId[0]}{targetItemModel.ModelInfo.PrimaryID.ToString().PadLeft(4, '0')}";
                 var targetMdlRace = "";
                 try
                 {
@@ -226,12 +226,12 @@ namespace FFXIV_TexTools.ViewModels
                     return;
                 }
                 
-                var targetVersion = $"v{targetItemModel.ModelInfo.Variant.ToString().PadLeft(4,'0')}";
+                var targetVersion = $"v{targetItemModel.ModelInfo.ImcSubsetID.ToString().PadLeft(4,'0')}";
 
                 var sameModelList = ItemList.Where(
-                    it => it.ItemCategory == targetItemModel.ItemCategory
-                    && (it as IItemModel).ModelInfo.ModelID == targetItemModel.ModelInfo.ModelID
-                    && (it as IItemModel).ModelInfo.Variant != targetItemModel.ModelInfo.Variant
+                    it => it.SecondaryCategory == targetItemModel.SecondaryCategory
+                    && (it as IItemModel).ModelInfo.PrimaryID == targetItemModel.ModelInfo.PrimaryID
+                    && (it as IItemModel).ModelInfo.ImcSubsetID != targetItemModel.ModelInfo.ImcSubsetID
                 );
                 
                 var fromQuery = list.Where(it => it.Name == item.Key).ToList();

--- a/FFXIV_TexTools/ViewModels/ModListViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModListViewModel.cs
@@ -337,7 +337,7 @@ namespace FFXIV_TexTools.ViewModels
             var item = new XivGenericItemModel
             {
                 Name = modItem.name,
-                ItemCategory = modItem.category,
+                SecondaryCategory = modItem.category,
                 DataFile = XivDataFiles.GetXivDataFile(modItem.datFile)
             };
 
@@ -345,32 +345,32 @@ namespace FFXIV_TexTools.ViewModels
             {
                 if (modItem.fullPath.Contains("chara/equipment") || modItem.fullPath.Contains("chara/accessory"))
                 {
-                    item.Category = XivStrings.Gear;
+                    item.PrimaryCategory = XivStrings.Gear;
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(17, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(17, 4))
                     };
                 }
 
                 if (modItem.fullPath.Contains("chara/weapon"))
                 {
-                    item.Category = XivStrings.Gear;
+                    item.PrimaryCategory = XivStrings.Gear;
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(14, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(14, 4))
                     };
                 }
 
                 if (modItem.fullPath.Contains("chara/human"))
                 {
-                    item.Category = XivStrings.Character;
+                    item.PrimaryCategory = XivStrings.Character;
 
 
                     if (item.Name.Equals(XivStrings.Body))
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(
+                            PrimaryID = int.Parse(
                                 fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
                         };
                     }
@@ -378,7 +378,7 @@ namespace FFXIV_TexTools.ViewModels
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(
+                            PrimaryID = int.Parse(
                                 fullPath.Substring(fullPath.IndexOf("/hair", StringComparison.Ordinal) + 7, 4))
                         };
                     }
@@ -386,7 +386,7 @@ namespace FFXIV_TexTools.ViewModels
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(
+                            PrimaryID = int.Parse(
                                 fullPath.Substring(fullPath.IndexOf("/face", StringComparison.Ordinal) + 7, 4))
                         };
                     }
@@ -394,7 +394,7 @@ namespace FFXIV_TexTools.ViewModels
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(
+                            PrimaryID = int.Parse(
                                 fullPath.Substring(fullPath.IndexOf("/tail", StringComparison.Ordinal) + 7, 4))
                         };
                     }
@@ -402,13 +402,13 @@ namespace FFXIV_TexTools.ViewModels
 
                 if (modItem.fullPath.Contains("chara/common"))
                 {
-                    item.Category = XivStrings.Character;
+                    item.PrimaryCategory = XivStrings.Character;
 
                     if (item.Name.Equals(XivStrings.Face_Paint))
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(
+                            PrimaryID = int.Parse(
                                 fullPath.Substring(fullPath.LastIndexOf("_", StringComparison.Ordinal) + 1, 1))
                         };
                     }
@@ -418,7 +418,7 @@ namespace FFXIV_TexTools.ViewModels
 
                         if (!fullPath.Contains("_stigma"))
                         {
-                            item.ModelInfo.ModelID = int.Parse(
+                            item.ModelInfo.PrimaryID = int.Parse(
                                 fullPath.Substring(fullPath.LastIndexOf("_", StringComparison.Ordinal) + 1, 3));
                         }
                     }
@@ -426,43 +426,43 @@ namespace FFXIV_TexTools.ViewModels
 
                 if (modItem.fullPath.Contains("chara/monster"))
                 {
-                    item.Category = XivStrings.Companions;
+                    item.PrimaryCategory = XivStrings.Companions;
 
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(15, 4)),
-                        Body = int.Parse(fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(15, 4)),
+                        SecondaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
                     };
                 }
 
                 if (modItem.fullPath.Contains("chara/demihuman"))
                 {
-                    item.Category = XivStrings.Companions;
+                    item.PrimaryCategory = XivStrings.Companions;
 
                     item.ModelInfo = new XivModelInfo
                     {
-                        Body = int.Parse(fullPath.Substring(17, 4)),
-                        ModelID = int.Parse(
+                        SecondaryID = int.Parse(fullPath.Substring(17, 4)),
+                        PrimaryID = int.Parse(
                             fullPath.Substring(fullPath.IndexOf("t/e", StringComparison.Ordinal) + 3, 4))
                     };
                 }
 
                 if (modItem.fullPath.Contains("ui/"))
                 {
-                    item.Category = XivStrings.UI;
+                    item.PrimaryCategory = XivStrings.UI;
 
                     if (modItem.fullPath.Contains("ui/uld") || modItem.fullPath.Contains("ui/map") || modItem.fullPath.Contains("ui/loadingimage"))
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = 0
+                            PrimaryID = 0
                         };
                     }
                     else
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("/", StringComparison.Ordinal) + 1,
+                            PrimaryID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("/", StringComparison.Ordinal) + 1,
                                 6))
                         };
                     }
@@ -470,11 +470,11 @@ namespace FFXIV_TexTools.ViewModels
 
                 if (modItem.fullPath.Contains("/hou/"))
                 {
-                    item.Category = XivStrings.Housing;
+                    item.PrimaryCategory = XivStrings.Housing;
 
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_m", StringComparison.Ordinal) + 2,
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_m", StringComparison.Ordinal) + 2,
                             4))
                     };
                 }
@@ -570,7 +570,7 @@ namespace FFXIV_TexTools.ViewModels
                         };
 
                         // Race
-                        if (selectedItem.Category.Equals(XivStrings.Gear))
+                        if (selectedItem.PrimaryCategory.Equals(XivStrings.Gear))
                         {
                             if (modItem.fullPath.Contains("equipment"))
                             {
@@ -591,7 +591,7 @@ namespace FFXIV_TexTools.ViewModels
                                 modListModel.Race = XivStrings.All;
                             }
                         }
-                        else if (selectedItem.Category.Equals(XivStrings.Character))
+                        else if (selectedItem.PrimaryCategory.Equals(XivStrings.Character))
                         {
                             if (!modItem.fullPath.Contains("chara/common"))
                             {
@@ -604,15 +604,15 @@ namespace FFXIV_TexTools.ViewModels
                             }
 
                         }
-                        else if (selectedItem.Category.Equals(XivStrings.Companions))
+                        else if (selectedItem.PrimaryCategory.Equals(XivStrings.Companions))
                         {
                             modListModel.Race = XivStrings.Monster;
                         }
-                        else if (selectedItem.Category.Equals(XivStrings.UI))
+                        else if (selectedItem.PrimaryCategory.Equals(XivStrings.UI))
                         {
                             modListModel.Race = XivStrings.All;
                         }
-                        else if (selectedItem.Category.Equals(XivStrings.Housing))
+                        else if (selectedItem.PrimaryCategory.Equals(XivStrings.Housing))
                         {
                             modListModel.Race = XivStrings.All;
                         }

--- a/FFXIV_TexTools/ViewModels/ModelSearchViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModelSearchViewModel.cs
@@ -218,14 +218,14 @@ namespace FFXIV_TexTools.ViewModels
                 var xivGear = new XivGear
                 {
                     Name = $"{SelectedCategory.ToLower()[0]}{_currentID.ToString().PadLeft(4, '0')}",
-                    Category = XivStrings.Gear,
-                    ItemCategory = SelectedItem.Slot,
+                    PrimaryCategory = XivStrings.Gear,
+                    SecondaryCategory = SelectedItem.Slot,
                     DataFile = XivDataFile._04_Chara,
                     ModelInfo = new XivModelInfo
                     {
-                        ModelID = _currentID,
-                        Body = body,
-                        Variant = variant
+                        PrimaryID = _currentID,
+                        SecondaryID = body,
+                        ImcSubsetID = variant
                     }
                 };
 
@@ -237,14 +237,14 @@ namespace FFXIV_TexTools.ViewModels
                 var xivMonster = new XivGenericItemModel
                 {
                     Name = $"{SelectedCategory.ToLower()[0]}{_currentID.ToString().PadLeft(4, '0')}",
-                    Category = XivStrings.Companions,
-                    ItemCategory = XivStrings.Monster,
+                    PrimaryCategory = XivStrings.Companions,
+                    SecondaryCategory = XivStrings.Monster,
                     DataFile = XivDataFile._04_Chara,
-                    ModelInfo = new XivModelInfo
+                    ModelInfo = new XivMonsterModelInfo
                     {
-                        ModelID = _currentID,
-                        Body = body,
-                        Variant = variant,
+                        PrimaryID = _currentID,
+                        SecondaryID = body,
+                        ImcSubsetID = variant,
                         ModelType = XivItemType.monster
                     }
                 };
@@ -257,14 +257,14 @@ namespace FFXIV_TexTools.ViewModels
                 var xivDemiHuman = new XivMount
                 {
                     Name = $"{SelectedCategory.ToLower()[0]}{_currentID.ToString().PadLeft(4, '0')}",
-                    Category = XivStrings.Companions,
-                    ItemCategory = XivStrings.Monster,
+                    PrimaryCategory = XivStrings.Companions,
+                    SecondaryCategory = XivStrings.Monster,
                     DataFile = XivDataFile._04_Chara,
-                    ModelInfo = new XivModelInfo
+                    ModelInfo = new XivMonsterModelInfo
                     {
-                        ModelID = _currentID,
-                        Body = body,
-                        Variant = variant,
+                        PrimaryID = _currentID,
+                        SecondaryID = body,
+                        ImcSubsetID = variant,
                         ModelType = XivItemType.demihuman
                     }
                 };
@@ -277,12 +277,12 @@ namespace FFXIV_TexTools.ViewModels
                 var xivFurniture = new XivFurniture
                 {
                     Name = $"{SelectedCategory.ToLower()[0]}{_currentID.ToString().PadLeft(4, '0')}",
-                    Category = XivStrings.Housing,
-                    ItemCategory = SelectedItem.Slot,
+                    PrimaryCategory = XivStrings.Housing,
+                    SecondaryCategory = SelectedItem.Slot,
                     DataFile = XivDataFile._01_Bgcommon,
                     ModelInfo = new XivModelInfo
                     {
-                        ModelID = _currentID
+                        PrimaryID = _currentID
                     }
                 };
 

--- a/FFXIV_TexTools/ViewModels/ModelSearchViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModelSearchViewModel.cs
@@ -229,8 +229,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                 };
 
-                await textureViewModel.UpdateTexture(xivGear);
-                await modelViewModel.UpdateModel(xivGear);
+                _mainView.SelectItem(xivGear, false);
             }
             else if (SelectedCategory.Equals(XivStrings.Monster))
             {
@@ -249,8 +248,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                 };
 
-                await textureViewModel.UpdateTexture(xivMonster);
-                await modelViewModel.UpdateModel(xivMonster);
+                _mainView.SelectItem(xivMonster, false);
             }
             else if (SelectedCategory.Equals(XivStrings.DemiHuman))
             {
@@ -269,8 +267,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                 };
 
-                await textureViewModel.UpdateTexture(xivDemiHuman);
-                await modelViewModel.UpdateModel(xivDemiHuman);
+                _mainView.SelectItem(xivDemiHuman, false);
             }
             else if (SelectedCategory.Equals(XivStrings.Furniture))
             {
@@ -286,8 +283,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                 };
 
-                await textureViewModel.UpdateTexture(xivFurniture);
-                await modelViewModel.UpdateModel(xivFurniture);
+                _mainView.SelectItem(xivFurniture, false);
             }
         }
 

--- a/FFXIV_TexTools/ViewModels/ModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModelViewModel.cs
@@ -36,6 +36,7 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
+using xivModdingFramework.Items;
 using xivModdingFramework.Items.Categories;
 using xivModdingFramework.Items.DataContainers;
 using xivModdingFramework.Items.Enums;
@@ -109,7 +110,7 @@ namespace FFXIV_TexTools.ViewModels
             _gameDirectory = new DirectoryInfo(Settings.Default.FFXIV_Directory);
             _mdl = new Mdl(_gameDirectory, _item.DataFile);
 
-            if (itemModel.Category.Equals(XivStrings.Gear))
+            if (itemModel.PrimaryCategory.Equals(XivStrings.Gear))
             {
                 var gear = new Gear(_gameDirectory, GetLanguage());
 
@@ -124,15 +125,15 @@ namespace FFXIV_TexTools.ViewModels
                     Races.Add(raceCBD);
                 }
             }
-            else if (itemModel.Category.Equals(XivStrings.Companions))
+            else if (itemModel.PrimaryCategory.Equals(XivStrings.Companions))
             {
                 var companions = new Companions(_gameDirectory, GetLanguage());
 
-                Races.Add(_item.ModelInfo.ModelType == XivItemType.demihuman
+                Races.Add(_item.GetPrimaryItemType() == XivItemType.demihuman
                     ? new ComboBoxData { Name = XivRace.DemiHuman.GetDisplayName(), XivRace = XivRace.DemiHuman }
                     : new ComboBoxData { Name = XivRace.Monster.GetDisplayName(), XivRace = XivRace.Monster });
             }
-            else if (itemModel.Category.Equals(XivStrings.Character))
+            else if (itemModel.PrimaryCategory.Equals(XivStrings.Character))
             {
                 var character = new Character(_gameDirectory, GetLanguage());
 
@@ -143,7 +144,7 @@ namespace FFXIV_TexTools.ViewModels
                     Races.Add(new ComboBoxData { Name = racesAndNumber.Key.GetDisplayName(), XivRace = racesAndNumber.Key });
                 }
             }
-            else if (itemModel.Category.Equals(XivStrings.Housing))
+            else if (itemModel.PrimaryCategory.Equals(XivStrings.Housing))
             {
                 Races.Add(new ComboBoxData { Name = XivRace.All_Races.GetDisplayName(), XivRace = XivRace.All_Races });
             }
@@ -232,11 +233,11 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         private void GetNumbers()
         {
-            if (_item.Category.Equals(XivStrings.Gear) || _item.Category.Equals(XivStrings.Companions) || _item.Category.Equals(XivStrings.Housing))
+            if (_item.PrimaryCategory.Equals(XivStrings.Gear) || _item.PrimaryCategory.Equals(XivStrings.Companions) || _item.PrimaryCategory.Equals(XivStrings.Housing))
             {
                 GetParts();
             }
-            else if (_item.Category.Equals(XivStrings.Character))
+            else if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 NumberVisibility = Visibility.Visible;
                 PartVisibility = Visibility.Visible;
@@ -330,11 +331,11 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         private async void GetParts()
         {
-            if (_item.Category.Equals(XivStrings.Gear))
+            if (_item.PrimaryCategory.Equals(XivStrings.Gear))
             {
                 var xivGear = _item as XivGear;
 
-                if (xivGear.ItemCategory.Equals(XivStrings.Rings))
+                if (xivGear.SecondaryCategory.Equals(XivStrings.Rings))
                 {
                     Parts.Add(new ComboBoxData { Name = XivStrings.Right });
                     Parts.Add(new ComboBoxData { Name = XivStrings.Left });
@@ -343,7 +344,7 @@ namespace FFXIV_TexTools.ViewModels
                 {
                     Parts.Add(new ComboBoxData { Name = XivStrings.Primary });
 
-                    if (xivGear.SecondaryModelInfo != null && xivGear.SecondaryModelInfo.ModelID > 0)
+                    if (xivGear.SecondaryModelInfo != null && xivGear.SecondaryModelInfo.PrimaryID > 0)
                     {
                         Parts.Add(new ComboBoxData { Name = XivStrings.Secondary });
                     }
@@ -351,7 +352,7 @@ namespace FFXIV_TexTools.ViewModels
 
                 PartVisibility = Visibility.Visible;
             }
-            else if (_item.Category.Equals(XivStrings.Character))
+            else if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 var character = new Character(_gameDirectory, GetLanguage());
 
@@ -363,9 +364,9 @@ namespace FFXIV_TexTools.ViewModels
                     Parts.Add(new ComboBoxData{ Name = part });
                 }
             }
-            else if (_item.Category.Equals(XivStrings.Companions))
+            else if (_item.PrimaryCategory.Equals(XivStrings.Companions))
             {
-                if (_item.ModelInfo.ModelType == XivItemType.demihuman)
+                if (_item.GetPrimaryItemType() == XivItemType.demihuman)
                 {
                     var companions = new Companions(_gameDirectory, GetLanguage());
                     var parts = await companions.GetDemiHumanMountModelEquipPartList(_item);
@@ -382,7 +383,7 @@ namespace FFXIV_TexTools.ViewModels
                     GetMeshes();
                 }
             }
-            else if (_item.Category.Equals(XivStrings.Housing))
+            else if (_item.PrimaryCategory.Equals(XivStrings.Housing))
             {
                 var housing = new Housing(_gameDirectory, GetLanguage());
                 var partsDictionary = await housing.GetFurnitureModelParts(_item);
@@ -478,7 +479,7 @@ namespace FFXIV_TexTools.ViewModels
 
             try
             {
-                if (_item.Category.Equals(XivStrings.Gear))
+                if (_item.PrimaryCategory.Equals(XivStrings.Gear))
                 {
                     var xivGear = _item as XivGear;
 
@@ -495,28 +496,28 @@ namespace FFXIV_TexTools.ViewModels
                         _mdlData = await _mdl.GetMdlData(xivGear, SelectedRace.XivRace, null, null, 0, SelectedPart.Name);
                     }
                 }
-                else if (_item.Category.Equals(XivStrings.Character))
+                else if (_item.PrimaryCategory.Equals(XivStrings.Character))
                 {
-                    _item.ModelInfo = new XivModelInfo { Body = int.Parse(SelectedNumber.Name) };
+                    _item.ModelInfo = new XivModelInfo { SecondaryID = int.Parse(SelectedNumber.Name) };
 
-                    ((XivCharacter)_item).ItemSubCategory = SelectedPart.Name;
+                    ((XivCharacter)_item).TertiaryCategory = SelectedPart.Name;
 
                     _mdlData = await _mdl.GetMdlData(_item, SelectedRace.XivRace);
                 }
-                else if (_item.Category.Equals(XivStrings.Companions))
+                else if (_item.PrimaryCategory.Equals(XivStrings.Companions))
                 {
-                    if (_item.ModelInfo.ModelType == XivItemType.demihuman)
+                    if (_item.GetPrimaryItemType() == XivItemType.demihuman)
                     {
-                        ((XivMount)_item).ItemSubCategory = SelectedPart.Name;
+                        ((XivMount)_item).TertiaryCategory = SelectedPart.Name;
                     }
 
                     _mdlData = await _mdl.GetMdlData(_item, SelectedRace.XivRace);
                 }
-                else if (_item.Category.Equals(XivStrings.Housing))
+                else if (_item.PrimaryCategory.Equals(XivStrings.Housing))
                 {
                     if (PartVisibility == Visibility.Visible)
                     {
-                        ((XivFurniture)_item).ItemSubCategory = SelectedPart.Name;
+                        ((XivFurniture)_item).TertiaryCategory = SelectedPart.Name;
                     }
 
                     _mdlData = await _mdl.GetMdlData(_item, SelectedRace.XivRace, null, SelectedPart.MdlPath);
@@ -639,7 +640,7 @@ namespace FFXIV_TexTools.ViewModels
             MeshWatermark = $"{XivStrings.Mesh}  |  {_meshCount}";
             PartWatermark = $"{XivStrings.Part}  |  {_partCount}";
 
-            if (_item.Category.Equals(XivStrings.Character))
+            if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 NumberWatermark = $"{XivStrings.Number}  |  {_numberCount}";
             }
@@ -1654,23 +1655,10 @@ namespace FFXIV_TexTools.ViewModels
             var materialNum = 0;
             foreach (var mtrlFilePath in mtrlFilePaths)
             {
-                var mtrlItem = new XivGenericItemModel
-                {
-                    Category = _item.Category,
-                    ItemCategory = _item.ItemCategory,
-                    ItemSubCategory = _item.ItemSubCategory,
-                    ModelInfo = new XivModelInfo
-                    {
-                        Body = _item.ModelInfo.Body,
-                        ModelID = _item.ModelInfo.ModelID,
-                        ModelType = _item.ModelInfo.ModelType,
-                        Variant = _item.ModelInfo.Variant
-                    },
-                    Name = _item.Name
-                };
+                var mtrlItem = (IItemModel) _item.Clone();
 
-                var modelID = mtrlItem.ModelInfo.ModelID;
-                var bodyID = mtrlItem.ModelInfo.Body;
+                var modelID = mtrlItem.ModelInfo.PrimaryID;
+                var bodyID = mtrlItem.ModelInfo.SecondaryID;
                 var filePath = mtrlFilePath;
 
                 if (!filePath.Contains("hou") && mtrlFilePath.Count(x => x == '/') > 1)
@@ -1709,12 +1697,12 @@ namespace FFXIV_TexTools.ViewModels
 
                         mtrlItem = new XivGenericItemModel
                         {
-                            Category = XivStrings.Character,
-                            ItemCategory = XivStrings.Body,
+                            PrimaryCategory = XivStrings.Character,
+                            SecondaryCategory = XivStrings.Body,
                             Name = XivStrings.Body,
                             ModelInfo = new XivModelInfo
                             {
-                                Body = int.Parse(body)
+                                SecondaryID = int.Parse(body)
                             }
                         };
 
@@ -1730,12 +1718,12 @@ namespace FFXIV_TexTools.ViewModels
 
                         mtrlItem = new XivGenericItemModel
                         {
-                            Category = XivStrings.Character,
-                            ItemCategory = XivStrings.Face,
+                            PrimaryCategory = XivStrings.Character,
+                            SecondaryCategory = XivStrings.Face,
                             Name = XivStrings.Face,
                             ModelInfo = new XivModelInfo
                             {
-                                Body = bodyID
+                                SecondaryID = bodyID
                             }
                         };
 
@@ -1748,12 +1736,12 @@ namespace FFXIV_TexTools.ViewModels
 
                         mtrlItem = new XivGenericItemModel
                         {
-                            Category = XivStrings.Character,
-                            ItemCategory = XivStrings.Hair,
+                            PrimaryCategory = XivStrings.Character,
+                            SecondaryCategory = XivStrings.Hair,
                             Name = XivStrings.Hair,
                             ModelInfo = new XivModelInfo
                             {
-                                Body = bodyID
+                                SecondaryID = bodyID
                             }
                         };
 
@@ -1770,12 +1758,12 @@ namespace FFXIV_TexTools.ViewModels
 
                         mtrlItem = new XivGenericItemModel
                         {
-                            Category = XivStrings.Character,
-                            ItemCategory = XivStrings.Tail,
+                            PrimaryCategory = XivStrings.Character,
+                            SecondaryCategory = XivStrings.Tail,
                             Name = XivStrings.Tail,
                             ModelInfo = new XivModelInfo
                             {
-                                Body = bodyID
+                                SecondaryID = bodyID
                             }
                         };
 
@@ -1792,12 +1780,12 @@ namespace FFXIV_TexTools.ViewModels
 
                         mtrlItem = new XivGenericItemModel
                         {
-                            Category = XivStrings.Character,
-                            ItemCategory = XivStrings.Ears,
+                            PrimaryCategory = XivStrings.Character,
+                            SecondaryCategory = XivStrings.Ears,
                             Name = XivStrings.Ears,
                             ModelInfo = new XivModelInfo
                             {
-                                Body = bodyID
+                                SecondaryID = bodyID
                             }
                         };
 
@@ -1811,7 +1799,7 @@ namespace FFXIV_TexTools.ViewModels
                         raceString = mtrlFilePath.Substring(mtrlFilePath.IndexOf("c") + 1, 4);
                         race = XivRaces.GetXivRace(raceString);
 
-                        mtrlItem.ModelInfo.ModelID = modelID;
+                        mtrlItem.ModelInfo.PrimaryID = modelID;
                         break;
                     // Accessory
                     case "ca":
@@ -1819,28 +1807,28 @@ namespace FFXIV_TexTools.ViewModels
                         raceString = mtrlFilePath.Substring(mtrlFilePath.IndexOf("c") + 1, 4);
                         race = XivRaces.GetXivRace(raceString);
 
-                        mtrlItem.ModelInfo.ModelID = modelID;
+                        mtrlItem.ModelInfo.PrimaryID = modelID;
                         break;
                     // Weapon
                     case "wb":
                         modelID = int.Parse(mtrlFilePath.Substring(mtrlFilePath.IndexOf("w") + 1, 4));
                         bodyID = int.Parse(mtrlFilePath.Substring(mtrlFilePath.IndexOf("b") + 1, 4));
-                        mtrlItem.ModelInfo.ModelID = modelID;
-                        mtrlItem.ModelInfo.Body = bodyID;
+                        mtrlItem.ModelInfo.PrimaryID = modelID;
+                        mtrlItem.ModelInfo.SecondaryID = bodyID;
                         break;
                     // Monster
                     case "mb":
                         modelID = int.Parse(mtrlFilePath.Substring(mtrlFilePath.IndexOf("_m") + 2, 4));
                         bodyID = int.Parse(mtrlFilePath.Substring(mtrlFilePath.IndexOf("b") + 1, 4));
-                        mtrlItem.ModelInfo.ModelID = modelID;
-                        mtrlItem.ModelInfo.Body = bodyID;
+                        mtrlItem.ModelInfo.PrimaryID = modelID;
+                        mtrlItem.ModelInfo.SecondaryID = bodyID;
                         break;
                     // DemiHuman
                     case "de":
                         modelID = int.Parse(mtrlFilePath.Substring(mtrlFilePath.IndexOf("d") + 1, 4));
                         bodyID = int.Parse(mtrlFilePath.Substring(mtrlFilePath.IndexOf("e") + 1, 4));
-                        mtrlItem.ModelInfo.ModelID = modelID;
-                        mtrlItem.ModelInfo.Body = bodyID;
+                        mtrlItem.ModelInfo.PrimaryID = modelID;
+                        mtrlItem.ModelInfo.SecondaryID = bodyID;
                         break;
                     default:
                         break;
@@ -1872,7 +1860,7 @@ namespace FFXIV_TexTools.ViewModels
                 }
                 else
                 {
-                    if (_item.ItemCategory.Equals(XivStrings.Face))
+                    if (_item.SecondaryCategory.Equals(XivStrings.Face))
                     {
                         var path = xivMtrl.Value.MTRLPath;
 

--- a/FFXIV_TexTools/ViewModels/SharedItemsViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/SharedItemsViewModel.cs
@@ -2,6 +2,7 @@
 using SharpDX.Toolkit.Graphics;
 using SharpDX.Win32;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -153,6 +154,17 @@ namespace FFXIV_TexTools.ViewModels
                     variantHeaders.Add(info.Variant, new TreeViewItem());
                     variantHeaders[info.Variant].Header = "Variant #" + info.Variant;
                     variantHeaders[info.Variant].DataContext = info.Variant;
+
+                    var hiddenParts = MaskToHidenParts(info.Mask);
+                    variantHeaders[info.Variant].Header += " - Hidden Parts: ";
+                    if (hiddenParts.Count > 0)
+                    {
+                        variantHeaders[info.Variant].Header += String.Join(",", hiddenParts);
+                    } else
+                    {
+                        variantHeaders[info.Variant].Header += "None";
+                    }
+
                 }
 
                 sharedItems[info.Variant].Add(i);
@@ -219,6 +231,33 @@ namespace FFXIV_TexTools.ViewModels
         private string CapFirst(string s)
         {
             return s[0].ToString().ToUpper() + s.Substring(1);
+        }
+
+        private List<char> MaskToHidenParts(ushort mask)
+        {
+            var ret = new List<char>();
+            BitArray bits = new BitArray(System.BitConverter.GetBytes(mask));
+
+
+            var idx = 0;
+            foreach(var b in bits)
+            {
+                // The Mask only uses the first 10 bits.
+                if(idx > 9)
+                {
+                    break;
+                }
+
+                var visible = (bool)b;
+                if(!visible)
+                {
+                    var letter = xivModdingFramework.Helpers.Constants.Alphabet[idx];
+                    ret.Add(letter);
+                }
+                idx++;
+            }
+
+            return ret;
         }
     }
 }

--- a/FFXIV_TexTools/ViewModels/SharedItemsViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/SharedItemsViewModel.cs
@@ -1,0 +1,224 @@
+﻿using FFXIV_TexTools.Views;
+using SharpDX.Toolkit.Graphics;
+using SharpDX.Win32;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using xivModdingFramework.General.Enums;
+using xivModdingFramework.Items;
+using xivModdingFramework.Items.Categories;
+using xivModdingFramework.Items.Enums;
+using xivModdingFramework.Items.Interfaces;
+using xivModdingFramework.Models.FileTypes;
+using xivModdingFramework.Variants.FileTypes;
+using static xivModdingFramework.Variants.FileTypes.Imc;
+
+namespace FFXIV_TexTools.ViewModels
+{
+    class SharedItemsViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        private SharedItemsView _view;
+        private MainWindow _mainWindow;
+        private IItem _item;
+        private TreeView _tree;
+        private Imc _imc;
+        private Gear _gear;
+
+        protected virtual void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public SharedItemsViewModel(SharedItemsView view)
+        {
+            _view = view;
+            _tree = _view.PrimaryTree;
+            var gameDirectory = new DirectoryInfo(Properties.Settings.Default.FFXIV_Directory);
+            _imc = new Imc(gameDirectory, XivDataFile._04_Chara);
+            _gear = new Gear(gameDirectory, XivLanguages.GetXivLanguage(Properties.Settings.Default.Application_Language));
+        }
+
+
+        /// <summary>
+        /// Updates the View/ViewModel with a new selected base item.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public async Task SetItem(IItem item, MainWindow mainWindow = null)
+        {
+            if (mainWindow != null)
+            {
+                _mainWindow = mainWindow;
+            }
+
+            var gameDirectory = new DirectoryInfo(Properties.Settings.Default.FFXIV_Directory);
+            _imc = new Imc(gameDirectory, item.DataFile);
+            _item = item;
+            _tree.Items.Clear();
+            IItemModel im = null;
+            try
+            {
+                im = (IItemModel)item;
+            } catch(Exception ex)
+            {
+                return;
+            }
+
+            if(im == null || im.ModelInfo == null)
+            {
+                return;
+            }
+
+            var topLevelItem = new TreeViewItem();
+            topLevelItem.Header = "";
+            if(im.ModelInfo.PrimaryID > 0)
+            {
+                topLevelItem.Header += CapFirst(item.GetPrimaryItemType().ToString()) + " #" + im.ModelInfo.PrimaryID.ToString().PadLeft(4, '0');
+            } else
+            {
+                topLevelItem.Header += CapFirst(item.GetPrimaryItemType().ToString());
+            }
+            _tree.Items.Add(topLevelItem);
+
+
+            var nextParent = topLevelItem;
+            if(im.ModelInfo.SecondaryID > 0)
+            {
+                var nextNode = new TreeViewItem();
+                nextNode.Header += CapFirst(item.GetSecondaryItemType().ToString()) + " #" + im.ModelInfo.SecondaryID.ToString().PadLeft(4, '0');
+                nextParent.Items.Add(nextNode);
+                nextParent.IsExpanded = true;
+                nextParent = nextNode;
+            }
+
+            var abbreviation = _item.GetItemSlotAbbreviation();
+            if (abbreviation != "")
+            {
+                var nextNode = new TreeViewItem();
+                nextNode.Header = Mdl.SlotAbbreviationDictionary.First(x => x.Value == abbreviation).Key;
+                nextParent.Items.Add(nextNode);
+                nextParent.IsExpanded = true;
+                nextParent = nextNode;
+            }
+
+            FullImcInfo fullInfo = null;
+            try
+            {
+                 fullInfo = await _imc.GetFullImcInfo(im);
+            } catch(Exception ex)
+            {
+                // This item has no IMC file.
+                var nextNode = new TreeViewItem();
+                nextNode.Header = im.Name;
+                nextNode.DataContext = im;
+                //nextNode.MouseDoubleClick += ItemNode_Activated;
+                nextParent.Items.Add(nextNode);
+                nextParent.IsExpanded = true;
+                nextNode.IsSelected = true;
+                nextParent = nextNode;
+                return;
+
+            }
+            var sharedList = await _gear.GetSameModelList(im);
+
+            var myVariantNumber = fullInfo.GetImcInfo(im.ModelInfo.ImcSubsetID, im.SecondaryCategory).Variant;
+
+            var sharedItems= new Dictionary<int, List<IItemModel>>();
+            var variantHeaders = new Dictionary<int, TreeViewItem>();
+
+            // TODO -
+            // Add the Variant header nodes at the start, and only scan the IMC files when a 
+
+            TreeViewItem myHeader = null;
+            TreeViewItem myNode = null;
+            foreach(var i in sharedList)
+            {
+                // Get the Variant # information
+                var info = fullInfo.GetImcInfo(i.ModelInfo.ImcSubsetID, i.SecondaryCategory);
+                if(info == null)
+                {
+                    // Invalid IMC Set ID for the item.
+                    continue;
+                }
+
+                if (!sharedItems.ContainsKey(info.Variant))
+                {
+                    sharedItems.Add(info.Variant, new List<IItemModel>());
+                    variantHeaders.Add(info.Variant, new TreeViewItem());
+                    variantHeaders[info.Variant].Header = "Variant #" + info.Variant;
+                    variantHeaders[info.Variant].DataContext = info.Variant;
+                }
+
+                sharedItems[info.Variant].Add(i);
+                var nextNode = new TreeViewItem();
+                nextNode.Header = i.Name;
+                nextNode.DataContext = i;
+                variantHeaders[info.Variant].Items.Add(nextNode);
+
+                
+                if(myHeader == null && info.Variant == myVariantNumber)
+                {
+                    myHeader = variantHeaders[info.Variant];
+                }
+
+                if (i.Name == im.Name)
+                {
+                    myNode = nextNode;
+                } else
+                {
+                    nextNode.MouseDoubleClick += ItemNode_Activated;
+                }
+            }
+
+            var ordered = variantHeaders.OrderBy(x => x.Key);
+
+            foreach(var kv in ordered)
+            {
+                nextParent.Items.Add(kv.Value);
+            }
+            nextParent.IsExpanded = true;
+
+            if (myHeader != null)
+            {
+                myHeader.IsExpanded = true;
+            }
+            if(myNode != null)
+            {
+                myNode.IsSelected = true;
+            }
+
+
+
+
+            //var topLevelItem = treeItem;
+
+
+
+            
+            //PrimaryTree.Clear
+        }
+
+        private void ItemNode_Activated(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            var treeItem = (TreeViewItem)sender;
+            var item = (IItem) treeItem.DataContext;
+            _mainWindow.SelectItem(item);
+        }
+
+        /// <summary>
+        /// Capitalize first letter of the given string.
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        private string CapFirst(string s)
+        {
+            return s[0].ToString().ToUpper() + s.Substring(1);
+        }
+    }
+}

--- a/FFXIV_TexTools/ViewModels/SharedItemsViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/SharedItemsViewModel.cs
@@ -51,7 +51,7 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         /// <param name="item"></param>
         /// <returns></returns>
-        public async Task SetItem(IItem item, MainWindow mainWindow = null)
+        public async Task<bool> SetItem(IItem item, MainWindow mainWindow = null)
         {
             if (mainWindow != null)
             {
@@ -68,12 +68,12 @@ namespace FFXIV_TexTools.ViewModels
                 im = (IItemModel)item;
             } catch(Exception ex)
             {
-                return;
+                return false;
             }
 
             if(im == null || im.ModelInfo == null)
             {
-                return;
+                return false;
             }
 
             var topLevelItem = new TreeViewItem();
@@ -123,7 +123,9 @@ namespace FFXIV_TexTools.ViewModels
                 nextParent.IsExpanded = true;
                 nextNode.IsSelected = true;
                 nextParent = nextNode;
-                return;
+
+                // No shared items for things without IMC files, so just hide the view entirely?
+                return false;
 
             }
             var sharedList = await _gear.GetSameModelList(im);
@@ -205,15 +207,7 @@ namespace FFXIV_TexTools.ViewModels
                 myNode.IsSelected = true;
             }
 
-
-
-
-            //var topLevelItem = treeItem;
-
-
-
-            
-            //PrimaryTree.Clear
+            return true;
         }
 
         private void ItemNode_Activated(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1610,7 +1610,10 @@ namespace FFXIV_TexTools.ViewModels
 
                 // Add new Materials for shared model items.    
                 var oldMaterialIdentifier = xivMtrl.GetMaterialIdentifier();
-                var sameModelItems = await _gear.GetSameModelList(_item);
+
+                // Ordering these by name ensures that we create textures for the new variants in the first
+                // item alphabetically, just for consistency's sake.
+                var sameModelItems = (await _gear.GetSameModelList(_item)).OrderBy(x => x.Name);
                 var oldVariantString = "/v" + xivMtrl.GetVariant().ToString().PadLeft(4,'0')  + '/';
                 var modifiedVariants = new List<int>();
 

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -732,24 +732,25 @@ namespace FFXIV_TexTools.ViewModels
                     if ((_item.SecondaryCategory.Equals(XivStrings.Mounts) || _item.SecondaryCategory.Equals(XivStrings.Monster)) && _item.GetPrimaryItemType() == XivItemType.demihuman)
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedType.Name[0], dxVersion);
+                        ttpList = _xivMtrl.GetTextureTypePathList();
                     }
                     else if (_item.PrimaryCategory.Equals(XivStrings.Gear))
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedType.Name[0], dxVersion, SelectedPart.Name);
+                        ttpList = _xivMtrl.GetTextureTypePathList();
 
                         var xivGear = _item as XivGear;
 
                         if (xivGear.IconNumber != 0)
                         {
-                            _xivMtrl.TextureTypePathList.AddRange(await _gear.GetIconInfo(xivGear));
+                            ttpList.AddRange(await _gear.GetIconInfo(xivGear));
                         }
                     }
                     else
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedPart.Name[0], dxVersion);
+                        ttpList = _xivMtrl.GetTextureTypePathList();
                     }
-
-                    ttpList = _xivMtrl.TextureTypePathList;
                 }
             }
             else
@@ -850,6 +851,22 @@ namespace FFXIV_TexTools.ViewModels
             }
             if (ttpList == null)
                 ttpList = new List<TexTypePath>();
+
+
+            // If the MTRL has VFX, retrieve those VFX textures as well.
+            if(_xivMtrl != null && _xivMtrl.hasVfx)
+            {
+                DirectoryInfo gameDirectory = new DirectoryInfo(Settings.Default.FFXIV_Directory);
+                var atex = new ATex(gameDirectory, _xivMtrl.GetDataFile());
+                try
+                {
+                    ttpList.AddRange(await atex.GetAtexPaths(_item));
+                }
+                catch
+                {
+                }
+            }
+
             foreach (var texTypePath in ttpList)
             {
                 if (texTypePath.Name != null)

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -122,7 +122,7 @@ namespace FFXIV_TexTools.ViewModels
             _tex = new Tex(gameDirectory);
             _modList = new Modding(gameDirectory);
 
-            if (item.Category.Equals(XivStrings.Gear))
+            if (item.PrimaryCategory.Equals(XivStrings.Gear))
             {
                 _category = XivStrings.Gear;
                 _item = item as IItemModel;
@@ -140,23 +140,23 @@ namespace FFXIV_TexTools.ViewModels
                     Races.Add(raceCBD);
                 }
             }
-            else if (item.Category.Equals(XivStrings.Companions))
+            else if (item.PrimaryCategory.Equals(XivStrings.Companions))
             {
                 _companions = new Companions(gameDirectory, GetLanguage());
                 _category = XivStrings.Companions;
                 _item = item as IItemModel;
 
-                Races.Add(_item.ModelInfo.ModelType == XivItemType.demihuman
+                Races.Add(_item.GetPrimaryItemType() == XivItemType.demihuman
                     ? new ComboBoxData {Name = XivRace.DemiHuman.GetDisplayName(), XivRace = XivRace.DemiHuman}
                     : new ComboBoxData {Name = XivRace.Monster.GetDisplayName(), XivRace = XivRace.Monster});
             }
-            else if (item.Category.Equals(XivStrings.Character))
+            else if (item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 _character = new Character(gameDirectory, GetLanguage());
                 _item = item as IItemModel;
 
-                if (_item.ItemCategory.Equals(XivStrings.Face_Paint) ||
-                    _item.ItemCategory.Equals(XivStrings.Equipment_Decals))
+                if (_item.SecondaryCategory.Equals(XivStrings.Face_Paint) ||
+                    _item.SecondaryCategory.Equals(XivStrings.Equipment_Decals))
                 {
                     Races.Add(new ComboBoxData{Name = XivRace.All_Races.GetDisplayName(), XivRace = XivRace.All_Races});
                 }
@@ -170,24 +170,24 @@ namespace FFXIV_TexTools.ViewModels
                     }
                 }
             }
-            else if (item.Category.Equals(XivStrings.UI))
+            else if (item.PrimaryCategory.Equals(XivStrings.UI))
             {
                 Races.Add(new ComboBoxData { Name = XivRace.All_Races.GetDisplayName(), XivRace = XivRace.All_Races });
 
                 _uiItem = item as XivUi;
             }
-            else if (item.Category.Equals(XivStrings.Housing))
+            else if (item.PrimaryCategory.Equals(XivStrings.Housing))
             {
                 Races.Add(new ComboBoxData { Name = XivRace.All_Races.GetDisplayName(), XivRace = XivRace.All_Races });
 
-                if (item.ItemCategory.Equals(XivStrings.Paintings))
+                if (item.SecondaryCategory.Equals(XivStrings.Paintings))
                 {
                     _uiItem = new XivUi
                     {
                         Name = item.Name,
-                        Category = item.Category,
-                        ItemCategory = item.ItemCategory,
-                        IconNumber = ((IItemModel)item).ModelInfo.ModelID,
+                        PrimaryCategory = item.PrimaryCategory,
+                        SecondaryCategory = item.SecondaryCategory,
+                        IconNumber = ((IItemModel)item).ModelInfo.PrimaryID,
                         DataFile = XivDataFile._06_Ui
                     };
                 }
@@ -277,14 +277,14 @@ namespace FFXIV_TexTools.ViewModels
                 // For character, the part list is used as a number list
                 List<string> partList;
 
-                if (_item.Category.Equals(XivStrings.Character))
+                if (_item.PrimaryCategory.Equals(XivStrings.Character))
                 {
-                    if (_item.ItemCategory.Equals(XivStrings.Face_Paint) ||
-                        _item.ItemCategory.Equals(XivStrings.Equipment_Decals))
+                    if (_item.SecondaryCategory.Equals(XivStrings.Face_Paint) ||
+                        _item.SecondaryCategory.Equals(XivStrings.Equipment_Decals))
                     {
                         partList = (await _character.GetDecalNums(_item)).Select(part => part.ToString()).ToList();
 
-                        if (_item.ItemCategory.Equals(XivStrings.Equipment_Decals))
+                        if (_item.SecondaryCategory.Equals(XivStrings.Equipment_Decals))
                         {
                             partList.Add("_stigma");
                         }
@@ -301,7 +301,7 @@ namespace FFXIV_TexTools.ViewModels
 
                     _partCount = partList.Count;
                 }
-                else if ((_item.ItemCategory.Equals(XivStrings.Mounts) || _item.ItemCategory.Equals(XivStrings.Monster)) && _item.ModelInfo.ModelType == XivItemType.demihuman)
+                else if ((_item.SecondaryCategory.Equals(XivStrings.Mounts) || _item.SecondaryCategory.Equals(XivStrings.Monster)) && _item.GetPrimaryItemType() == XivItemType.demihuman)
                 {
                     var equipParts = await _companions.GetDemiHumanMountTextureEquipPartList(_item);
 
@@ -312,13 +312,13 @@ namespace FFXIV_TexTools.ViewModels
 
                     _partCount = equipParts.Count;
                 }
-                else if (_item.Category.Equals(XivStrings.Gear))
+                else if (_item.PrimaryCategory.Equals(XivStrings.Gear))
                 {
                     var xivGear = _item as XivGear;
 
                     Parts.Add(new ComboBoxData { Name = XivStrings.Primary });
 
-                    if (xivGear.SecondaryModelInfo != null && xivGear.SecondaryModelInfo.ModelID > 0)
+                    if (xivGear.SecondaryModelInfo != null && xivGear.SecondaryModelInfo.PrimaryID > 0)
                     {
                         Parts.Add(new ComboBoxData{Name = XivStrings.Secondary});
                     }
@@ -422,7 +422,7 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         private async void GetTexType()
         {
-            if (_item.Category.Equals(XivStrings.Character))
+            if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 TypeVisibility = Visibility.Visible;
                 // Create the model info for character
@@ -430,11 +430,11 @@ namespace FFXIV_TexTools.ViewModels
 
                 if (!SelectedPart.Name.Equals("_stigma"))
                 {
-                    _item.ModelInfo.Body = int.Parse(SelectedPart.Name);
+                    _item.ModelInfo.SecondaryID = int.Parse(SelectedPart.Name);
                 }
 
                 // For hair and face we get the type (Hair, Accessory, Face, Iris, Etc)
-                if (_item.ItemCategory.Equals(XivStrings.Hair) || _item.ItemCategory.Equals(XivStrings.Face) || _item.ItemCategory.Equals(XivStrings.Ears))
+                if (_item.SecondaryCategory.Equals(XivStrings.Hair) || _item.SecondaryCategory.Equals(XivStrings.Face) || _item.SecondaryCategory.Equals(XivStrings.Ears))
                 {
                     TypePartVisibility = Visibility.Visible;
                     var charaTypeParts = await _character.GetTypePartForTextures(_item as XivCharacter, SelectedRace.XivRace,
@@ -446,7 +446,7 @@ namespace FFXIV_TexTools.ViewModels
                         Types.Add(new ComboBoxData{Name = charaTypePart.Key, TypeParts = charaTypePart.Value});
                     }
                 }
-                else if (_item.ItemCategory.Equals(XivStrings.Body) || _item.ItemCategory.Equals(XivStrings.Tail))
+                else if (_item.SecondaryCategory.Equals(XivStrings.Body) || _item.SecondaryCategory.Equals(XivStrings.Tail))
                 {
                     TypePartVisibility = Visibility.Visible;
                     var parts = await _character.GetVariantsForTextures(_item as XivCharacter, SelectedRace.XivRace, int.Parse(SelectedPart.Name));
@@ -470,11 +470,11 @@ namespace FFXIV_TexTools.ViewModels
 
                 SelectedTypeIndex = 0;
             }
-            else if ((_item.ItemCategory.Equals(XivStrings.Mounts) || _item.ItemCategory.Equals(XivStrings.Monster)) && _item.ModelInfo.ModelType == XivItemType.demihuman)
+            else if ((_item.SecondaryCategory.Equals(XivStrings.Mounts) || _item.SecondaryCategory.Equals(XivStrings.Monster)) && _item.GetPrimaryItemType() == XivItemType.demihuman)
             {
                 TypeVisibility = Visibility.Visible;
 
-                ((XivMount)_item).ItemSubCategory = SelectedPart.Name;
+                ((XivMount)_item).TertiaryCategory = SelectedPart.Name;
 
                 var parts = SelectedPart.TypeParts;
                 _typeCount = parts.Length;
@@ -490,7 +490,7 @@ namespace FFXIV_TexTools.ViewModels
 
                 SelectedTypeIndex = 0;
             }
-            else if(_item.Category.Equals(XivStrings.Gear))
+            else if(_item.PrimaryCategory.Equals(XivStrings.Gear))
             {
                 TypeVisibility = Visibility.Visible;
 
@@ -535,8 +535,8 @@ namespace FFXIV_TexTools.ViewModels
                 if (SelectedTypeIndex > -1)
                 {
                     Maps.Clear();
-                    if (_item.Category.Equals(XivStrings.Character) && (_item.ItemCategory.Equals(XivStrings.Hair) || _item.ItemCategory.Equals(XivStrings.Face) ||
-                        _item.ItemCategory.Equals(XivStrings.Ears) || _item.ItemCategory.Equals(XivStrings.Body) || _item.ItemCategory.Equals(XivStrings.Tail)))
+                    if (_item.PrimaryCategory.Equals(XivStrings.Character) && (_item.SecondaryCategory.Equals(XivStrings.Hair) || _item.SecondaryCategory.Equals(XivStrings.Face) ||
+                        _item.SecondaryCategory.Equals(XivStrings.Ears) || _item.SecondaryCategory.Equals(XivStrings.Body) || _item.SecondaryCategory.Equals(XivStrings.Tail)))
                     {
                         TypeParts.Clear();
                         GetTypeParts();
@@ -591,14 +591,14 @@ namespace FFXIV_TexTools.ViewModels
         {
             var typeParts = SelectedType.TypeParts;
 
-            if (_item.Category.Equals(XivStrings.Character))
+            if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
-                if (_item.ItemCategory.Equals(XivStrings.Body) || _item.ItemCategory.Equals(XivStrings.Tail))
+                if (_item.SecondaryCategory.Equals(XivStrings.Body) || _item.SecondaryCategory.Equals(XivStrings.Tail))
                 {
                     typeParts = await _character.GetPartForTextures(_item as XivCharacter, SelectedRace.XivRace, int.Parse(SelectedPart.Name), int.Parse(SelectedType.Name));
                 }
 
-                ((XivCharacter)_item).ItemSubCategory = SelectedType.Name;
+                ((XivCharacter)_item).TertiaryCategory = SelectedType.Name;
             }
 
             foreach (var typePart in typeParts)
@@ -684,15 +684,15 @@ namespace FFXIV_TexTools.ViewModels
             List<TexTypePath> ttpList;
             if (_item != null)
             {
-                if (_item.Category.Equals(XivStrings.Character))
+                if (_item.PrimaryCategory.Equals(XivStrings.Character))
                 {
-                    if (_item.ItemCategory.Equals(XivStrings.Face_Paint))
+                    if (_item.SecondaryCategory.Equals(XivStrings.Face_Paint))
                     {
                         var path = $"{XivStrings.FacePaintFolder}/{string.Format(XivStrings.FacePaintFile, SelectedPart.Name)}";
 
                         ttpList = new List<TexTypePath> { new TexTypePath { DataFile = _item.DataFile, Path = path, Type = XivTexType.Mask } };
                     }
-                    else if (_item.ItemCategory.Equals(XivStrings.Equipment_Decals))
+                    else if (_item.SecondaryCategory.Equals(XivStrings.Equipment_Decals))
                     {
                         var path = $"{XivStrings.EquipDecalFolder}/{string.Format(XivStrings.EquipDecalFile, SelectedPart.Name)}";
 
@@ -729,11 +729,11 @@ namespace FFXIV_TexTools.ViewModels
                 }
                 else
                 {
-                    if ((_item.ItemCategory.Equals(XivStrings.Mounts) || _item.ItemCategory.Equals(XivStrings.Monster)) && _item.ModelInfo.ModelType == XivItemType.demihuman)
+                    if ((_item.SecondaryCategory.Equals(XivStrings.Mounts) || _item.SecondaryCategory.Equals(XivStrings.Monster)) && _item.GetPrimaryItemType() == XivItemType.demihuman)
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedType.Name[0], dxVersion);
                     }
-                    else if (_item.Category.Equals(XivStrings.Gear))
+                    else if (_item.PrimaryCategory.Equals(XivStrings.Gear))
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedType.Name[0], dxVersion, SelectedPart.Name);
 
@@ -757,7 +757,7 @@ namespace FFXIV_TexTools.ViewModels
                 if (_uiItem.UiPath != null)
                 {
                     string path;
-                    if (_uiItem.ItemCategory.Equals(XivStrings.Maps))
+                    if (_uiItem.SecondaryCategory.Equals(XivStrings.Maps))
                     {
                         var mapNamePaths = await _tex.GetMapAvailableTex(_uiItem.UiPath);
 
@@ -776,13 +776,13 @@ namespace FFXIV_TexTools.ViewModels
                             ttpList.Add(ttp);
                         }
                     }
-                    else if(_uiItem.ItemCategory.Equals(XivStrings.HUD))
+                    else if(_uiItem.SecondaryCategory.Equals(XivStrings.HUD))
                     {
                         path = $"{_uiItem.UiPath}/{_uiItem.Name.ToLower()}.tex";
 
                         ttpList = new List<TexTypePath> { new TexTypePath { DataFile = _uiItem.DataFile, Path = path, Type = XivTexType.Mask } };
                     }
-                    else if (_uiItem.ItemCategory.Equals(XivStrings.Loading_Screen))
+                    else if (_uiItem.SecondaryCategory.Equals(XivStrings.Loading_Screen))
                     {
                         path = $"{_uiItem.UiPath}/{_uiItem.Name.ToLower()}.tex";
 
@@ -790,7 +790,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                     else
                     {
-                        if (_uiItem.ItemCategory.Equals("Icon"))
+                        if (_uiItem.SecondaryCategory.Equals("Icon"))
                         {
                             var index = new Index(new DirectoryInfo(Properties.Settings.Default.FFXIV_Directory));
                             var languages = new[] {"en", "ja", "fr", "de"};
@@ -965,7 +965,7 @@ namespace FFXIV_TexTools.ViewModels
             {
                 var dxVersion = int.Parse(Properties.Settings.Default.DX_Version);
 
-                if (_item.Category.Equals(XivStrings.Character))
+                if (_item.PrimaryCategory.Equals(XivStrings.Character))
                 {
                     if (TypePartVisibility == Visibility.Visible)
                     {
@@ -978,11 +978,11 @@ namespace FFXIV_TexTools.ViewModels
                 }
                 else
                 {
-                    if ((_item.ItemCategory.Equals(XivStrings.Mounts) || _item.ItemCategory.Equals(XivStrings.Monster)) && _item.ModelInfo.ModelType == XivItemType.demihuman)
+                    if ((_item.SecondaryCategory.Equals(XivStrings.Mounts) || _item.SecondaryCategory.Equals(XivStrings.Monster)) && _item.GetPrimaryItemType() == XivItemType.demihuman)
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedType.Name[0], dxVersion);
                     }
-                    else if (_item.Category.Equals(XivStrings.Gear))
+                    else if (_item.PrimaryCategory.Equals(XivStrings.Gear))
                     {
                         _xivMtrl = await _mtrl.GetMtrlData(_item, SelectedRace.XivRace, SelectedType.Name[0], dxVersion, SelectedPart.Name);
                     }
@@ -1045,7 +1045,7 @@ namespace FFXIV_TexTools.ViewModels
 
             if (_item != null)
             {
-                if (_item.ItemCategory.Equals(XivStrings.Hair) || _item.ItemCategory.Equals(XivStrings.Equipment_Decals) || _item.ItemCategory.Equals(XivStrings.Face_Paint))
+                if (_item.SecondaryCategory.Equals(XivStrings.Hair) || _item.SecondaryCategory.Equals(XivStrings.Equipment_Decals) || _item.SecondaryCategory.Equals(XivStrings.Face_Paint))
                 {
                     AddNewTexturePartEnabled = false;
                 }
@@ -1482,7 +1482,7 @@ namespace FFXIV_TexTools.ViewModels
                 var partChars = new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
                 List<string> partList = new List<string>();
 
-                if (_item.Category.Equals(XivStrings.Character))
+                if (_item.PrimaryCategory.Equals(XivStrings.Character))
                 {
                     partList = TypeParts.Select(it => it.Name).ToList();
                 } else
@@ -1590,7 +1590,7 @@ namespace FFXIV_TexTools.ViewModels
                     // - This isn't always the same as the item model variant, for some reason.
                     // - So it has to be resolved manually.
                     var variantMtrlPath = "";
-                    var itemType = ItemType.GetItemType(_item);
+                    var itemType = ItemType.GetPrimaryItemType(_item);
 
 
                     if (TypePartVisibility == Visibility.Visible)
@@ -1664,11 +1664,11 @@ namespace FFXIV_TexTools.ViewModels
                 void SetToNewTexturePart(object sender, EventArgs e)
                 {
                     LoadingComplete -= SetToNewTexturePart;
-                    if (_item.Category.Equals(XivStrings.Gear))
+                    if (_item.PrimaryCategory.Equals(XivStrings.Gear))
                     {
                         SelectedType = Types[Types.Count - 1];
                     }
-                    else if (_item.Category.Equals(XivStrings.Character))
+                    else if (_item.PrimaryCategory.Equals(XivStrings.Character))
                     {
                         SelectedTypePart = TypeParts[TypeParts.Count - 1];
                     }
@@ -1717,35 +1717,19 @@ namespace FFXIV_TexTools.ViewModels
             var ui = new UI(gameDirectory, GetLanguage());
             var housing = new Housing(gameDirectory, GetLanguage());
             //gear
-            if (_item.Category.Equals(XivStrings.Gear))
+            if (_item.PrimaryCategory.Equals(XivStrings.Gear))
             {
                 sameModelItems.AddRange(
                     (await gear.GetGearList())
                     .Where(it =>
-                    it.ModelInfo.ModelID == _item.ModelInfo.ModelID
-                    && it.ItemCategory == _item.ItemCategory).Select(it => it as IItemModel).ToList()
+                    it.ModelInfo.PrimaryID == _item.ModelInfo.PrimaryID
+                    && it.SecondaryCategory == _item.SecondaryCategory).Select(it => it as IItemModel).ToList()
                 );
             }
-            else if (_item.Category.Equals(XivStrings.Character))
+            else if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 //character
-                sameModelItems.Add(
-                    new XivGenericItemModel
-                    {
-                        Category = _item.Category,
-                        ItemCategory = _item.ItemCategory,
-                        ItemSubCategory = _item.ItemSubCategory,
-                        ModelInfo = new XivModelInfo
-                        {
-                            Body = _item.ModelInfo.Body,
-                            ModelID = _item.ModelInfo.ModelID,
-                            ModelType = _item.ModelInfo.ModelType,
-                            Variant = _item.ModelInfo.Variant
-                        },
-                        Name = _item.Name
-                    }
-                    as IItemModel
-                );
+                sameModelItems.Add((IItemModel)_item.Clone()) ;
             }
             //companions
             //sameModelItems.AddRange(
@@ -1903,11 +1887,11 @@ namespace FFXIV_TexTools.ViewModels
             RaceWatermark = $"{XivStrings.Race}  |  {_raceCount}";
             TextureMapWatermark = $"{XivStrings.Texture_Map}  |  {_mapCount}";
 
-            if (_item.Category.Equals(XivStrings.Character))
+            if (_item.PrimaryCategory.Equals(XivStrings.Character))
             {
                 PartWatermark = $"{XivStrings.Number}  |  {_partCount}";
 
-                if (_item.ItemCategory.Equals(XivStrings.Body))
+                if (_item.SecondaryCategory.Equals(XivStrings.Body))
                 {
                     TypeWatermark = XivStrings.Variant;
                     TypePartWatermark = XivStrings.Part;
@@ -1922,7 +1906,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                 }
             }
-            else if (_item.ItemCategory.Equals(XivStrings.Mounts) && _item.ModelInfo.ModelType == XivItemType.demihuman)
+            else if (_item.SecondaryCategory.Equals(XivStrings.Mounts) && _item.GetPrimaryItemType() == XivItemType.demihuman)
             {
                 PartWatermark = $"{XivStrings.Type}  |  {_partCount}";
                 TypeWatermark = $"{XivStrings.Part}  |  {_typeCount}";

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1552,6 +1552,26 @@ namespace FFXIV_TexTools.ViewModels
                 // Detokenize them using the new paths.
                 var mapInfos = xivMtrl.GetAllMapInfos(true);
 
+
+                var hasDiffuse = false;
+                var hasMulti = false;
+                var hasSpecular = false;
+                foreach(var info in mapInfos)
+                {
+                    if(info.Usage == XivTexType.Diffuse)
+                    {
+                        hasDiffuse = true;
+                    } else if(info.Usage == XivTexType.Multi)
+                    {
+                        hasMulti = true;
+                    } else if(info.Usage == XivTexType.Specular)
+                    {
+                        hasSpecular = true;
+                    }
+                }
+
+
+
                 // Shader info likewise will be pumped into each new material.
                 var shaderInfo = xivMtrl.GetShaderInfo();
 
@@ -1645,6 +1665,20 @@ namespace FFXIV_TexTools.ViewModels
                     foreach (var info in mapInfos)
                     {
                         itemXivMtrl.SetMapInfo(info.Usage, info);
+                    }
+
+                    // Clear any unused maps.
+                    if (!hasDiffuse)
+                    {
+                        itemXivMtrl.SetMapInfo(XivTexType.Diffuse, null);
+                    }
+                    if (!hasMulti)
+                    {
+                        itemXivMtrl.SetMapInfo(XivTexType.Multi, null);
+                    }
+                    if (!hasSpecular)
+                    {
+                        itemXivMtrl.SetMapInfo(XivTexType.Specular, null);
                     }
 
                     // Load the Shader Settings

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1479,7 +1479,7 @@ namespace FFXIV_TexTools.ViewModels
                     return;
 
                 // Get new Material Identifier
-                var partChars = new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
+                var partChars = Constants.Alphabet;
                 List<string> partList = new List<string>();
 
                 if (_item.PrimaryCategory.Equals(XivStrings.Character))
@@ -1593,7 +1593,7 @@ namespace FFXIV_TexTools.ViewModels
 
                 // Add new Materials for shared model items.    
                 var oldMaterialIdentifier = xivMtrl.GetMaterialIdentifier();
-                var sameModelItems = await GetSameModelList();
+                var sameModelItems = await _gear.GetSameModelList(_item);
                 var oldVariantString = "/v" + xivMtrl.GetVariant().ToString().PadLeft(4,'0')  + '/';
                 var modifiedVariants = new List<int>();
 
@@ -1741,58 +1741,6 @@ namespace FFXIV_TexTools.ViewModels
             }
         }
 
-        async Task<List<IItemModel>> GetSameModelList()
-        {
-            var gameDirectory = new DirectoryInfo(Settings.Default.FFXIV_Directory);
-            var sameModelItems=new List<IItemModel>();
-            var gear = new Gear(gameDirectory, GetLanguage());
-            var character = new Character(gameDirectory, GetLanguage());
-            var companions = new Companions(gameDirectory, GetLanguage());
-            var ui = new UI(gameDirectory, GetLanguage());
-            var housing = new Housing(gameDirectory, GetLanguage());
-            //gear
-            if (_item.PrimaryCategory.Equals(XivStrings.Gear))
-            {
-                sameModelItems.AddRange(
-                    (await gear.GetGearList())
-                    .Where(it =>
-                    it.ModelInfo.PrimaryID == _item.ModelInfo.PrimaryID
-                    && it.SecondaryCategory == _item.SecondaryCategory).Select(it => it as IItemModel).ToList()
-                );
-            }
-            else if (_item.PrimaryCategory.Equals(XivStrings.Character))
-            {
-                //character
-                sameModelItems.Add((IItemModel)_item.Clone()) ;
-            }
-            //companions
-            //sameModelItems.AddRange(
-            //    (await companions.GetMinionList())
-            //    .Where(it =>
-            //    it.ModelInfo.ModelID == _item.ModelInfo.ModelID
-            //    && it.ItemCategory == _item.ItemCategory).Select(it => it as IItemModel).ToList()
-            //);
-            //sameModelItems.AddRange(
-            //    (await companions.GetMountList())
-            //    .Where(it =>
-            //    it.ModelInfo.ModelID == _item.ModelInfo.ModelID
-            //    && it.ItemCategory == _item.ItemCategory).Select(it => it as IItemModel).ToList()
-            //);
-            //sameModelItems.AddRange(
-            //    (await companions.GetPetList())
-            //    .Where(it =>
-            //    it.ModelInfo.ModelID == _item.ModelInfo.ModelID
-            //    && it.ItemCategory == _item.ItemCategory).Select(it => it as IItemModel).ToList()
-            //);
-            //housing
-            //sameModelItems.AddRange(
-            //    (await housing.GetFurnitureList())
-            //    .Where(it =>
-            //    it.ModelInfo.ModelID == _item.ModelInfo.ModelID
-            //    && it.ItemCategory == _item.ItemCategory).Select(it => it as IItemModel).ToList()
-            //);
-            return sameModelItems;
-        }
 
         /// <summary>
         /// The enabled status for the export button

--- a/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
@@ -292,73 +292,73 @@ namespace FFXIV_TexTools.Views
             var item = new XivGenericItemModel
             {
                 Name = modItem.name,
-                ItemCategory = modItem.category,
+                SecondaryCategory = modItem.category,
                 DataFile = XivDataFiles.GetXivDataFile(modItem.datFile)
             };
 
 
             if (modItem.fullPath.Contains("chara/equipment") || modItem.fullPath.Contains("chara/accessory"))
             {
-                item.Category = XivStrings.Gear;
+                item.PrimaryCategory = XivStrings.Gear;
                 item.ModelInfo = new XivModelInfo
                 {
-                    ModelID = int.Parse(fullPath.Substring(17, 4))
+                    PrimaryID = int.Parse(fullPath.Substring(17, 4))
                 };
             }
 
 
             if (modItem.fullPath.Contains("chara/weapon"))
             {
-                item.Category = XivStrings.Gear;
+                item.PrimaryCategory = XivStrings.Gear;
                 item.ModelInfo = new XivModelInfo
                 {
-                    ModelID = int.Parse(fullPath.Substring(14, 4))
+                    PrimaryID = int.Parse(fullPath.Substring(14, 4))
                 };
             }
 
             if (modItem.fullPath.Contains("chara/human"))
             {
-                item.Category = XivStrings.Character;
+                item.PrimaryCategory = XivStrings.Character;
 
                 if (item.Name.Equals(XivStrings.Body))
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
                     };
                 }
                 else if (item.Name.Equals(XivStrings.Hair))
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.IndexOf("/hair", StringComparison.Ordinal) + 7, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("/hair", StringComparison.Ordinal) + 7, 4))
                     };
                 }
                 else if (item.Name.Equals(XivStrings.Face))
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.IndexOf("/face", StringComparison.Ordinal) + 7, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("/face", StringComparison.Ordinal) + 7, 4))
                     };
                 }
                 else if (item.Name.Equals(XivStrings.Tail))
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.IndexOf("/tail", StringComparison.Ordinal) + 7, 4))
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("/tail", StringComparison.Ordinal) + 7, 4))
                     };
                 }
             }
 
             if (modItem.fullPath.Contains("chara/common"))
             {
-                item.Category = XivStrings.Character;
+                item.PrimaryCategory = XivStrings.Character;
 
                 if (item.Name.Equals(XivStrings.Face_Paint))
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_", StringComparison.Ordinal) + 1, 1))
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_", StringComparison.Ordinal) + 1, 1))
                     };
                 }
                 else if (item.Name.Equals(XivStrings.Equipment_Decals))
@@ -367,7 +367,7 @@ namespace FFXIV_TexTools.Views
                     {
                         item.ModelInfo = new XivModelInfo
                         {
-                            ModelID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_", StringComparison.Ordinal) + 1, 3))
+                            PrimaryID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_", StringComparison.Ordinal) + 1, 3))
                         };
                     }
                 }
@@ -375,42 +375,42 @@ namespace FFXIV_TexTools.Views
 
             if (modItem.fullPath.Contains("chara/monster"))
             {
-                item.Category = XivStrings.Companions;
+                item.PrimaryCategory = XivStrings.Companions;
 
                 item.ModelInfo = new XivModelInfo
                 {
-                    ModelID = int.Parse(fullPath.Substring(15, 4)),
-                    Body = int.Parse(fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
+                    PrimaryID = int.Parse(fullPath.Substring(15, 4)),
+                    SecondaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("/body", StringComparison.Ordinal) + 7, 4))
                 };
             }
 
             if (modItem.fullPath.Contains("chara/demihuman"))
             {
-                item.Category = XivStrings.Companions;
+                item.PrimaryCategory = XivStrings.Companions;
 
                 item.ModelInfo = new XivModelInfo
                 {
-                    Body = int.Parse(fullPath.Substring(17, 4)),
-                    ModelID = int.Parse(fullPath.Substring(fullPath.IndexOf("t/e", StringComparison.Ordinal) + 3, 4))
+                    SecondaryID = int.Parse(fullPath.Substring(17, 4)),
+                    PrimaryID = int.Parse(fullPath.Substring(fullPath.IndexOf("t/e", StringComparison.Ordinal) + 3, 4))
                 };
             }
 
             if (modItem.fullPath.Contains("ui/"))
             {
-                item.Category = XivStrings.UI;
+                item.PrimaryCategory = XivStrings.UI;
 
                 if (modItem.fullPath.Contains("ui/uld") || modItem.fullPath.Contains("ui/map"))
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = 0
+                        PrimaryID = 0
                     };
                 }
                 else
                 {
                     item.ModelInfo = new XivModelInfo
                     {
-                        ModelID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("/", StringComparison.Ordinal) + 1,
+                        PrimaryID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("/", StringComparison.Ordinal) + 1,
                             6))
                     };
                 }
@@ -418,11 +418,11 @@ namespace FFXIV_TexTools.Views
 
             if (modItem.fullPath.Contains("/hou/"))
             {
-                item.Category = XivStrings.Housing;
+                item.PrimaryCategory = XivStrings.Housing;
 
                 item.ModelInfo = new XivModelInfo
                 {
-                    ModelID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_m", StringComparison.Ordinal) + 2, 3))
+                    PrimaryID = int.Parse(fullPath.Substring(fullPath.LastIndexOf("_m", StringComparison.Ordinal) + 2, 3))
                 };
             }
 
@@ -742,9 +742,9 @@ namespace FFXIV_TexTools.Views
                     }
                     else
                     {
-                        var modelId = ((IItemModel)selectedItem.Item).ModelInfo.ModelID;
+                        var modelId = ((IItemModel)selectedItem.Item).ModelInfo.PrimaryID;
 
-                        if (selectedItem.Item.Category.Equals(XivStrings.Character))
+                        if (selectedItem.Item.PrimaryCategory.Equals(XivStrings.Character))
                         {
                             var item = selectedItem.Item;
 

--- a/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
@@ -627,13 +627,18 @@ namespace FFXIV_TexTools.Views
         /// </summary>
         private void TreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
+            var selectedItem = e.NewValue as Category;
+            if (selectedItem == null || selectedItem.Item == null)
+            {
+                return;
+            }
+
             TextureMapComboBox.Items.Clear();
             ModelTypeComboBox.Items.Clear();
             MaterialComboBox.Items.Clear();
             CustomTextureTextBox.Text = string.Empty;
             CustomModelTextBox.Text = string.Empty;
 
-            var selectedItem = e.NewValue as Category;
 
             var modList = JsonConvert.DeserializeObject<ModList>(File.ReadAllText(_modListDirectory.FullName));
 

--- a/FFXIV_TexTools/Views/Models/AdvancedModelImportView.xaml.cs
+++ b/FFXIV_TexTools/Views/Models/AdvancedModelImportView.xaml.cs
@@ -79,7 +79,7 @@ namespace FFXIV_TexTools.Views.Models
         /// </summary>
         private void ForceUV1Quadrant_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            if (_itemModel.Category.Equals(FFXIV_TexTools.Resources.XivStrings.Gear))
+            if (_itemModel.PrimaryCategory.Equals(FFXIV_TexTools.Resources.XivStrings.Gear))
             {
                 Properties.Settings.Default.ForceUV1Quadrant = _viewModel.ForceUV1QuadrantChecked;
                 Properties.Settings.Default.Save();
@@ -91,7 +91,7 @@ namespace FFXIV_TexTools.Views.Models
         /// </summary>
         private void CloneUV1toUV2_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            if (_itemModel.ItemCategory.Equals(FFXIV_TexTools.Resources.XivStrings.Hair))
+            if (_itemModel.SecondaryCategory.Equals(FFXIV_TexTools.Resources.XivStrings.Hair))
             {
                 Properties.Settings.Default.CloneUV1toUV2 = _viewModel.CloneUV1toUV2Checked;
                 Properties.Settings.Default.Save();

--- a/FFXIV_TexTools/Views/SharedItems/SharedItemsView.xaml
+++ b/FFXIV_TexTools/Views/SharedItems/SharedItemsView.xaml
@@ -1,0 +1,45 @@
+﻿<UserControl
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+    xmlns:local="clr-namespace:FFXIV_TexTools.Views"
+    xmlns:resx="clr-namespace:FFXIV_TexTools.Resources" xmlns:controls="clr-namespace:FFXIV_TexTools.Controls"
+    x:Class="FFXIV_TexTools.Views.SharedItemsView"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="DarkSquareColor" Color="#CC000000" />
+        <SolidColorBrush x:Key="LightSquareColor" Color="#BF000000" />
+        <Style x:Key="{x:Type xctk:Zoombox}" TargetType="{x:Type xctk:Zoombox}">
+            <Style.Triggers>
+                <Trigger Property="AreDragModifiersActive" Value="True">
+                    <Setter Property="Cursor" Value="SizeAll" />
+                </Trigger>
+                <Trigger Property="AreZoomModifiersActive" Value="True">
+                    <Setter Property="Cursor" Value="Arrow" />
+                </Trigger>
+                <Trigger Property="AreZoomToSelectionModifiersActive" Value="True">
+                    <Setter Property="Cursor" Value="Cross" />
+                </Trigger>
+                <Trigger Property="AreRelativeZoomModifiersActive" Value="True">
+                    <Setter Property="Cursor" Value="Arrow" />
+                </Trigger>
+                <!-- The IsDraggingContent and IsSelectingRegion triggers should 
+           always be last. -->
+                <Trigger Property="IsDraggingContent" Value="True">
+                    <Setter Property="Cursor" Value="SizeAll" />
+                </Trigger>
+                <Trigger Property="IsSelectingRegion" Value="True">
+                    <Setter Property="Cursor" Value="Cross" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+    <Grid>
+        <TreeView x:Name="PrimaryTree" Margin="10"/>
+    </Grid>
+</UserControl>

--- a/FFXIV_TexTools/Views/SharedItems/SharedItemsView.xaml.cs
+++ b/FFXIV_TexTools/Views/SharedItems/SharedItemsView.xaml.cs
@@ -1,0 +1,25 @@
+﻿using FFXIV_TexTools.ViewModels;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using xivModdingFramework.Items.Interfaces;
+using xivModdingFramework.Materials.DataContainers;
+
+namespace FFXIV_TexTools.Views
+{
+    /// <summary>
+    /// Interaction logic for MaterialEditor.xaml
+    /// </summary>
+    public partial class SharedItemsView : UserControl
+    {
+        private SharedItemsViewModel _viewModel;
+        public SharedItemsView()
+        {
+            InitializeComponent();
+
+            this._viewModel = new SharedItemsViewModel(this);
+            this.DataContext = this._viewModel;
+        }
+
+    }
+}


### PR DESCRIPTION
List of things in this PR at this point
   - Fixed error with Material Addition not adding materials for many shared items.
   - Fixed error with Material Addition not properly removing old Texture references.
   - Fixed crash when switching to Secondary Material for dual-wield weapons. 
   - Fixed crash in the modpack editor when selecting top level categories in the tree view.
   - Added Variants tab to the main application.
   - Disabled Tabs in the main application will now be hidden, rather than simply non-interactive.
   - Internal refactoring of IItem and IMC data members.
   - Verbiage adjustments to tab names ( Pluralization of Texture(s) and Model(s) )
   - VFX textures are now labeled as VFX textures and listed after Icon/IconHQ.
   - Textures now display their name after their texture type.  Ex [Normal] -> [Normal: v01_whatever_n]
   - Texture paths in the material editor now have [.tex] suffixed onto them if they do not already end in .tex or .atex.
   - Materials and Textures generated by the Material Editor when adding a new Material will now be listed under the *alphabetically first* item for each Variant, for consistency.
