### PR TITLE
Preset Driven Material Editor

### DIFF
--- a/FFXIV_TexTools/ViewModels/MaterialEditorViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MaterialEditorViewModel.cs
@@ -1,25 +1,22 @@
-﻿using FFXIV_TexTools.Resources;
+﻿using FFXIV_TexTools.Helpers;
+using FFXIV_TexTools.Resources;
 using FFXIV_TexTools.Views.Textures;
-using HelixToolkit.Wpf;
-using HelixToolkit.Wpf.SharpDX;
-using Newtonsoft.Json;
-using SharpDX.D3DCompiler;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Xceed.Wpf.Toolkit.PropertyGrid.Attributes;
 using xivModdingFramework.General.Enums;
+using xivModdingFramework.Items;
+using xivModdingFramework.Items.Categories;
 using xivModdingFramework.Items.Interfaces;
 using xivModdingFramework.Materials.DataContainers;
 using xivModdingFramework.Materials.FileTypes;
 using xivModdingFramework.Mods;
-using xivModdingFramework.Mods.DataContainers;
-using xivModdingFramework.Textures.DataContainers;
+using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Textures.Enums;
+using Constants = xivModdingFramework.Helpers.Constants;
 
 namespace FFXIV_TexTools.ViewModels
 {
@@ -39,29 +36,56 @@ namespace FFXIV_TexTools.ViewModels
 
     class MaterialEditorViewModel
     {
-        public bool WriteFile = false;
+        public MaterialEditorMode _mode;
 
         private MaterialEditorView _view;
         private Mtrl _mtrl;
+        private Index _index;
+        private Gear _gear;
+        private Modding _modding;
         private XivMtrl _material;
         private IItemModel _item;
+        private char _newMaterialIdentifier;
         public MaterialEditorViewModel(MaterialEditorView view)
         {
             _view = view;
         }
 
-        public void SetMaterial(XivMtrl material, IItemModel item, bool writeFile = true)
+        public async Task<bool> SetMaterial(XivMtrl material, IItemModel item, MaterialEditorMode mode)
         {
             if (material == null)
             {
-                return;
+                return false;
             }
 
-            WriteFile = writeFile;
+            _mode = mode;
+            _material = material;
+            _item = item;
 
             var gameDirectory = new DirectoryInfo(Properties.Settings.Default.FFXIV_Directory);
             _mtrl = new Mtrl(gameDirectory, item.DataFile, GetLanguage());
+            _index = new Index(gameDirectory);
+            _modding = new Modding(gameDirectory);
+            _gear = new Gear(gameDirectory, GetLanguage());
 
+
+            // Drop the multi functions down to singles if they only have one Material to edit anyways.
+            if(_mode == MaterialEditorMode.EditMulti || _mode == MaterialEditorMode.NewMulti)
+            {
+                // This isn't an actual perfect check for if there's only one Variant, but doing so
+                // would be a bit expensive here, and passing it through EditMulti isn't harmful anyways.
+                var sameModelItems = await _gear.GetSameModelList(_item);
+                if(sameModelItems.Count == 1)
+                {
+                    if (_mode == MaterialEditorMode.EditMulti)
+                    {
+                        _mode = MaterialEditorMode.EditSingle;
+                    } else
+                    {
+                        _mode = MaterialEditorMode.NewSingle;
+                    }
+                }
+            }
 
             /*
             // Debug code for finding unknown Shader Parameters.
@@ -80,16 +104,22 @@ namespace FFXIV_TexTools.ViewModels
             }
             */
 
-            _material = material;
-            _item = item;
 
             // Update to new material name
-            if (WriteFile)
+            switch(_mode)
             {
-                _view.MaterialPathLabel.Text = _material.MTRLPath;
-            } else
-            {
-                _view.MaterialPathLabel.Text = "New Material(s)";
+                case MaterialEditorMode.EditSingle:
+                    _view.MaterialPathLabel.Text = _material.MTRLPath;
+                    break;
+                case MaterialEditorMode.EditMulti:
+                    _view.MaterialPathLabel.Text = "Editing Multiple Materials: Material " + _material.GetMaterialIdentifier();
+                    break;
+                case MaterialEditorMode.NewSingle:
+                    _view.MaterialPathLabel.Text = "New Material";
+                    break;
+                case MaterialEditorMode.NewMulti:
+                    _view.MaterialPathLabel.Text = "New Materials";
+                    break;
             }
 
             var shader = _material.GetShaderInfo();
@@ -119,18 +149,29 @@ namespace FFXIV_TexTools.ViewModels
             _view.PresetComboBox.SelectedValue = shader.Preset;
 
 
-
-            var modding = new Modding(gameDirectory);
-
-            // Asyncrhonously get the mod entry.
-            var task = modding.TryGetModEntry(_material.MTRLPath);
-            task.Wait();
-            var mod = task.Result;
-            if (mod != null && mod.enabled)
+            if(_mode == MaterialEditorMode.NewMulti )
             {
-                _view.DisableButton.IsEnabled = true;
-                _view.DisableButton.Visibility = System.Windows.Visibility.Visible;
+                // Bump up the material identifier letter.
+                _newMaterialIdentifier = await GetNewMaterialIdentifier();
+                _view.MaterialPathLabel.Text = "New Materials: Material " + _newMaterialIdentifier;
+            } else if(_mode == MaterialEditorMode.NewSingle)
+            {
+                _newMaterialIdentifier = await GetNewMaterialIdentifier();
+                _view.MaterialPathLabel.Text = "New Material: Material " + _newMaterialIdentifier;
             }
+
+            // Get the mod entry.
+            if (_mode == MaterialEditorMode.EditSingle || _mode == MaterialEditorMode.EditMulti)
+            {
+                var mod = await _modding.TryGetModEntry(_material.MTRLPath);
+                if (mod != null && mod.enabled)
+                {
+                    _view.DisableButton.IsEnabled = true;
+                    _view.DisableButton.Visibility = System.Windows.Visibility.Visible;
+                }
+            }
+
+            return true;
         }
 
         public XivMtrl GetMaterial()
@@ -156,6 +197,10 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         public async Task<XivMtrl> SaveChanges()
         {
+            _view.SaveButton.IsEnabled = false;
+            _view.CancelButton.IsEnabled = false;
+            _view.DisableButton.IsEnabled = false;
+            _view.SaveButton.Content = "Working...";
             _view.NormalTextBox.Text = SanitizePath(_view.NormalTextBox.Text);
             _view.DiffuseTextBox.Text = SanitizePath(_view.DiffuseTextBox.Text);
             _view.SpecularTextBox.Text = SanitizePath(_view.SpecularTextBox.Text);
@@ -204,34 +249,194 @@ namespace FFXIV_TexTools.ViewModels
             _material.SetMapInfo(XivTexType.Reflection, newReflection);
 
 
-            if (WriteFile)
+            try
             {
-                // Write the new MTRLs - ImportMtrl automatically generates any missing textures.
-                var newMtrlOffset = await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools);
+                if (_mode == MaterialEditorMode.EditSingle)
+                {
+                    // Just save the existing MTRL.
+                    await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools);
+                } else if(_mode == MaterialEditorMode.NewSingle)
+                {
+                    // Update the existing MTRL to a new path and save it.
+                    _material.MTRLPath = Regex.Replace(_material.MTRLPath, "_([a-z0-9])\\.mtrl", "_" + _newMaterialIdentifier + ".mtrl");
+                    await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools);
+                }
+                else if (_mode == MaterialEditorMode.NewMulti || _mode == MaterialEditorMode.EditMulti)
+                {
+                    // Ship it to the more complex save function.
+                    await SaveMulti();
+
+                    // Change this after calling SaveMulti.  Updated so that the external classes looking for the material after
+                    // can find the right type identifier and such.
+                    _material.MTRLPath = Regex.Replace(_material.MTRLPath, "_([a-z0-9])\\.mtrl", "_" + _newMaterialIdentifier + ".mtrl");
+                }
+            } catch (Exception Ex)
+            {
+                FlexibleMessageBox.Show("An error occurred when saving the Material.");
             }
             return _material;
         }
 
+        public async Task<char> GetNewMaterialIdentifier()
+        {
+
+            // Get new Material Identifier
+            var alphabet = Constants.Alphabet;
+            List<string> partList = new List<string>();
+
+            var materialIdentifier = _material.GetMaterialIdentifier();
+
+            var newIdentifier = '\0';
+            for (var i = 1; i < alphabet.Length; i++)
+            {
+                var identifier = alphabet[i];
+                var newPath = Regex.Replace(_material.MTRLPath, "_([a-z0-9])\\.mtrl", "_" + identifier + ".mtrl");
+                var exists = await _index.FileExists(newPath);
+                if(!exists)
+                {
+                    return identifier;
+                }
+            }
+
+            // No empty material names left.
+            // Note - This can be fixed.  Materials don't need to be named a-z, but realisitcally is anyone going to have more than 26 materials?
+            if (newIdentifier == '\0')
+            {
+                throw new NotSupportedException("Maximum Material Limit Reached.");
+            }
+            return newIdentifier;
+
+        }
+
+        public async Task SaveMulti()
+        {
+
+            // Get tokenized map info structs.
+            // This will let us set them in the new Materials and
+            // Detokenize them using the new paths.
+            var mapInfos = _material.GetAllMapInfos(true);
+
+
+            // Shader info likewise will be pumped into each new material.
+            var shaderInfo = _material.GetShaderInfo();
+
+            // Add new Materials for shared model items.    
+            var oldMaterialIdentifier = _material.GetMaterialIdentifier();
+
+            // Ordering these by name ensures that we create textures for the new variants in the first
+            // item alphabetically, just for consistency's sake.
+            var sameModelItems = (await _gear.GetSameModelList(_item)).OrderBy(x => x.Name);
+            var oldVariantString = "/v" + _material.GetVariant().ToString().PadLeft(4, '0') + '/';
+            var modifiedVariants = new List<int>();
+
+
+            var mtrlReplacementRegex = "_" + oldMaterialIdentifier + ".mtrl";
+            var mtrlReplacementRegexResult = "_" + _newMaterialIdentifier + ".mtrl";
+
+
+            // Load and modify all the MTRLs.
+            foreach (var item in sameModelItems)
+            {
+
+                // Resolve this item's material variant.
+                // - This isn't always the same as the item model variant, for some reason.
+                // - So it has to be resolved manually.
+                var variantMtrlPath = "";
+                var itemType = ItemType.GetPrimaryItemType(_item);
+
+                
+                variantMtrlPath = (await _mtrl.GetMtrlPath(item, _material.GetRace(), oldMaterialIdentifier, itemType, XivStrings.Primary)).Folder;
+
+                var match = Regex.Match(variantMtrlPath, "/v([0-9]+)");
+                var variant = 0;
+                if (match.Success)
+                {
+                    variant = Int32.Parse(match.Groups[1].Value);
+                }
+
+                // Only modify each Variant once.
+                if (modifiedVariants.Contains(variant))
+                {
+                    continue;
+                }
+
+                var dxVersion = 11;
+                XivMtrl itemXivMtrl;
+
+                // Get mtrl path -- TODO: Need support here for offhand item materials.
+                // But Offhand support is basically completely broken anyways, so this can wait.
+                itemXivMtrl = await _mtrl.GetMtrlData(_item, _material.GetRace(), oldMaterialIdentifier, dxVersion, XivStrings.Primary);
+
+                // Shift the MTRL to the new variant folder.
+                itemXivMtrl.MTRLPath = Regex.Replace(itemXivMtrl.MTRLPath, oldVariantString, "/v" + variant.ToString().PadLeft(4, '0') + "/");
+
+                if (_mode == MaterialEditorMode.NewMulti)
+                {
+                    // Change the MTRL part identifier.
+                    itemXivMtrl.MTRLPath = Regex.Replace(itemXivMtrl.MTRLPath, mtrlReplacementRegex, mtrlReplacementRegexResult);
+                }
+
+                // Load the Shader Settings
+                itemXivMtrl.SetShaderInfo(shaderInfo, true);
+
+                // Loop our tokenized map infos and pump them back in
+                // using the new modified material to detokenize them.
+                foreach (var info in mapInfos)
+                {
+                    itemXivMtrl.SetMapInfo(info.Usage, info);
+                }
+
+                // Write the new Material
+                await _mtrl.ImportMtrl(itemXivMtrl, item, XivStrings.TexTools);
+                modifiedVariants.Add(variant);
+                _view.SaveStatusLabel.Content = "Updated " + modifiedVariants.Count + " Variants...";
+            }
+
+        }
+
         public async Task DisableMod()
         {
-            var gameDirectory = new DirectoryInfo(Properties.Settings.Default.FFXIV_Directory);
-            var modding = new Modding(gameDirectory);
-            var modEntry = await modding.TryGetModEntry(_material.MTRLPath);
+            _view.SaveButton.IsEnabled = false;
+            _view.CancelButton.IsEnabled = false;
+            _view.DisableButton.IsEnabled = false;
+            _view.DisableButton.Content = "Working...";
+            var files = new List<string>();
 
-            if (!modEntry.enabled)
-            {
-                _view.Close(false);
-                return;
+            // If we're disabling from the Edit Multi menu, diable all variant versions as well.
+            if (_mode == MaterialEditorMode.EditMulti) {
+                var sameModelItems = await _gear.GetSameModelList(_item);
+                var itemType = ItemType.GetPrimaryItemType(_item);
+                // Find all the variant materials 
+                foreach (var item in sameModelItems)
+                {
+                    var variantPath = await _mtrl.GetMtrlPath(item, _material.GetRace(), _material.GetMaterialIdentifier(), itemType, XivStrings.Primary);
+                    files.Add(variantPath.Folder + "/" + variantPath.File);
+                }
+            } else {
+                // Just disabling this one.
+                files.Add(_material.MTRLPath);
             }
 
-            // If the file is a custom addition, and not a modification.
-            if (modEntry.source != XivStrings.TexTools)
+            files = files.Distinct().ToList();
+
+            foreach(var file in files)
             {
-                await modding.DeleteMod(_material.MTRLPath);
-            }
-            else
-            {
-                await modding.ToggleModStatus(_material.MTRLPath, false);
+                var modEntry = await _modding.TryGetModEntry(file);
+
+                if (!modEntry.enabled)
+                {
+                    continue;
+                }
+
+                // If the file is a custom addition, and not a modification.
+                if (modEntry.source != XivStrings.TexTools)
+                {
+                    await _modding.DeleteMod(file);
+                }
+                else
+                {
+                    await _modding.ToggleModStatus(file, false);
+                }
             }
             _view.Close(false);
         }

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1529,6 +1529,7 @@ namespace FFXIV_TexTools.ViewModels
                 // Make sure we have access to write the data files.
                 var gameDirectory = new DirectoryInfo(Settings.Default.FFXIV_Directory);
                 var index = new Index(gameDirectory);
+                _gear = new Gear(gameDirectory, GetLanguage());
                 if (index.IsIndexLocked(XivDataFile._04_Chara))
                 {
                     FlexibleMessageBox.Show(UIMessages.IndexLockedErrorMessage,
@@ -1599,11 +1600,11 @@ namespace FFXIV_TexTools.ViewModels
                 // Set our blank colorset info.
                 if (xivMtrl.ColorSetData != null && xivMtrl.ColorSetData.Count > 0)
                 {
-                    colorSetData = _tex.GetColorsetDataFromDDS(Tex.GetDefaultTexturePath(XivTexType.ColorSet));
+                    colorSetData = Tex.GetColorsetDataFromDDS(Tex.GetDefaultTexturePath(XivTexType.ColorSet));
                 }
                 if (xivMtrl.ColorSetDataSize == 544)
                 {
-                    colorSetExtraData = _tex.GetColorsetExtraDataFromDDS(Tex.GetDefaultTexturePath(XivTexType.ColorSet));
+                    colorSetExtraData = Tex.GetColorsetExtraDataFromDDS(Tex.GetDefaultTexturePath(XivTexType.ColorSet));
                 }
 
 

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1680,6 +1680,9 @@ namespace FFXIV_TexTools.ViewModels
                     // Change the MTRL part identifier.
                     itemXivMtrl.MTRLPath = Regex.Replace(itemXivMtrl.MTRLPath, mtrlReplacementRegex, mtrlReplacementRegexResult);
 
+                    // Load the Shader Settings
+                    itemXivMtrl.SetShaderInfo(shaderInfo, true);
+
                     // Loop our tokenized map infos and pump them back in
                     // using the new modified material to detokenize them.
                     foreach (var info in mapInfos)
@@ -1687,22 +1690,7 @@ namespace FFXIV_TexTools.ViewModels
                         itemXivMtrl.SetMapInfo(info.Usage, info);
                     }
 
-                    // Clear any unused maps.
-                    if (!hasDiffuse)
-                    {
-                        itemXivMtrl.SetMapInfo(XivTexType.Diffuse, null);
-                    }
-                    if (!hasMulti)
-                    {
-                        itemXivMtrl.SetMapInfo(XivTexType.Multi, null);
-                    }
-                    if (!hasSpecular)
-                    {
-                        itemXivMtrl.SetMapInfo(XivTexType.Specular, null);
-                    }
 
-                    // Load the Shader Settings
-                    itemXivMtrl.SetShaderInfo(shaderInfo);
 
                     // Load Colorset Data
                     itemXivMtrl.ColorSetData = colorSetData;

--- a/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml
+++ b/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml
@@ -51,5 +51,6 @@
         <Button x:Name="CopyMaterialButton" Content="Copy Material" HorizontalAlignment="Left" Margin="243,12,0,0" VerticalAlignment="Top" Width="102" Grid.Column="3" Grid.Row="1" Click="CopyMaterialButton_Click"/>
         <Button x:Name="PasteMaterialButton" Content="Paste Material" HorizontalAlignment="Left" Margin="243,12,0,0" Grid.Row="2" VerticalAlignment="Top" Width="102" Grid.Column="3" Click="PasteMaterialButton_Click"/>
         <Button x:Name="DisableButton" Content="Disable/Delete" Margin="170,0,0,10" Grid.Row="7" FontSize="12" HorizontalAlignment="Left" Width="150" Height="30" VerticalAlignment="Bottom" Click="DisableButton_Click" Grid.ColumnSpan="4"/>
+        <Label x:Name="SaveStatusLabel" Content="" Grid.Column="2" HorizontalAlignment="Left" Margin="29,12,0,0" Grid.Row="7" VerticalAlignment="Top" Grid.ColumnSpan="2" Width="269" HorizontalContentAlignment="Right" FontStyle="Italic"/>
     </Grid>
 </mah:MetroWindow>

--- a/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml
+++ b/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml
@@ -9,12 +9,13 @@
         xmlns:resx="clr-namespace:FFXIV_TexTools.Resources"
         xmlns:input="clr-namespace:System.Windows.Input;assembly=PresentationCore"
         mc:Ignorable="d"
-        Title="{Binding Source={x:Static resx:UIStrings.Material_Editor}}" Height="385.576" IsMinButtonEnabled="False" IsMaxRestoreButtonEnabled="False" WindowStartupLocation="CenterOwner" FontSize="14" Width="766.682">
+        Title="{Binding Source={x:Static resx:UIStrings.Material_Editor}}" Height="451.576" IsMinButtonEnabled="False" IsMaxRestoreButtonEnabled="False" WindowStartupLocation="CenterOwner" FontSize="14" Width="766.682">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="118*"/>
             <ColumnDefinition Width="178*"/>
-            <ColumnDefinition Width="463*"/>
+            <ColumnDefinition Width="108*"/>
+            <ColumnDefinition Width="355*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="50*"/>
@@ -24,26 +25,30 @@
             <RowDefinition Height="50*"/>
             <RowDefinition Height="50*"/>
             <RowDefinition Height="50*"/>
+            <RowDefinition Height="50*"/>
         </Grid.RowDefinitions>
         <ComboBox x:Name="ShaderComboBox" Margin="10,13,10,0" VerticalAlignment="Top" Height="26" Grid.Column="1" Grid.Row="1" SelectionChanged="ShaderComboBox_SelectionChanged" />
-        <Label Content="Normal:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="3" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="63" HorizontalContentAlignment="Right"/>
-        <ComboBox x:Name="NormalComboBox" Margin="10,13,10,0" VerticalAlignment="Top" Height="26" Grid.Column="1" Grid.Row="3"/>
-        <Label Content="Specular:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="4" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="71" HorizontalContentAlignment="Right"/>
-        <ComboBox x:Name="SpecularComboBox" Margin="10,13,10,0" VerticalAlignment="Top" Height="26" Grid.Column="1" Grid.Row="4" SelectionChanged="SpecularComboBox_SelectionChanged" />
-        <Label Content="Diffuse:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="5" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="61" HorizontalContentAlignment="Right"/>
-        <ComboBox x:Name="DiffuseComboBox" Margin="10,13,10,0" VerticalAlignment="Top" Height="26" Grid.Column="1" Grid.Row="5" SelectionChanged="DiffuseComboBox_SelectionChanged" />
+        <Label Content="Normal:" Margin="10,14,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="4" RenderTransformOrigin="0.164,0.793" HorizontalContentAlignment="Right"/>
+        <Label x:Name="SpecularLabel" Content="Specular:" Margin="10,13,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="5" RenderTransformOrigin="0.164,0.793" HorizontalContentAlignment="Right"/>
+        <Label x:Name="DiffuseLabel" Content="Diffuse:" Margin="10,13,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="6" RenderTransformOrigin="0.164,0.793" HorizontalContentAlignment="Right"/>
         <Label Content="Transparency:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="2" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="100" HorizontalContentAlignment="Right"/>
         <ComboBox x:Name="TransparencyComboBox" Margin="10,13,10,0" VerticalAlignment="Top" Height="26" Grid.Column="1" Grid.Row="2" />
-        <Button x:Name="SaveButton" Content="Save" Grid.Column="2" Margin="0,0,10,10" Grid.Row="6" FontSize="12" HorizontalAlignment="Right" Width="135" Height="30" VerticalAlignment="Bottom"/>
+        <Button x:Name="SaveButton" Content="Save" Grid.Column="3" Margin="0,0,10,10" Grid.Row="7" FontSize="12" HorizontalAlignment="Right" Width="135" Height="30" VerticalAlignment="Bottom"/>
         <Label Content="Shader:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="63" Grid.Row="1" HorizontalContentAlignment="Right"/>
-        <TextBox x:Name="NormalTextBox" Grid.Column="2" Height="26" Margin="10,13,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="3"/>
-        <TextBox x:Name="SpecularTextBox" Grid.Column="2" Height="26" Margin="10,13,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="4"/>
-        <TextBox x:Name="DiffuseTextBox" Grid.Column="2" Height="26" Margin="10,13,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="5"/>
-        <Label Margin="0" Grid.ColumnSpan="3" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" FontSize="14" FontWeight="Bold" FontStyle="Italic">
+        <TextBox x:Name="NormalTextBox" Grid.Column="1" Height="26" Margin="10,17,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="4" Grid.ColumnSpan="3"/>
+        <TextBox x:Name="SpecularTextBox" Grid.Column="1" Height="26" Margin="10,16,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="5" Grid.ColumnSpan="3"/>
+        <TextBox x:Name="DiffuseTextBox" Grid.Column="1" Height="26" Margin="10,16,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="6" Grid.ColumnSpan="3"/>
+        <Label Margin="0" Grid.ColumnSpan="4" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" FontSize="14" FontWeight="Bold" FontStyle="Italic">
             <TextBlock x:Name="MaterialPathLabel"  Text="Material Path" TextAlignment="Right" FontWeight="Bold" FontSize="14" FontStyle="Italic" />
         </Label>
-        <Button x:Name="CancelButton" Content="Cancel" Margin="0,0,151,10" Grid.Row="6" FontSize="12" Click="CancelButton_Click" HorizontalAlignment="Right" Width="135" Height="30" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Cursor=""/>
-        <Label Content="Paths" Grid.Column="2" Margin="0" Grid.Row="2" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom" Cursor="Arrow"/>
-        <Button Content="Help" Grid.Column="2" HorizontalAlignment="Left" Margin="387,21,0,0" Grid.Row="2" VerticalAlignment="Top" Width="66" Click="Button_Click"/>
+        <Button x:Name="CancelButton" Content="Cancel" Margin="0,0,151,10" Grid.Row="7" FontSize="12" Click="CancelButton_Click" HorizontalAlignment="Right" Width="135" Height="30" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Cursor="" RenderTransformOrigin="0.415,1.067"/>
+        <Label Content="Texture Paths" Margin="0" Grid.Row="3" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom" Cursor="Arrow" Grid.ColumnSpan="4" FontWeight="Bold" FontStyle="Italic"/>
+        <Button Content="Help" Grid.Column="3" HorizontalAlignment="Left" Margin="243,16,0,0" Grid.Row="3" VerticalAlignment="Top" Width="102" Click="HelpButton_Click"/>
+        <ComboBox x:Name="PresetComboBox" Margin="10,13,136,0" VerticalAlignment="Top" Height="26" Grid.Column="3" Grid.Row="1" SelectionChanged="PresetComboBox_SelectionChanged" />
+        <Label Content="Preset:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="86" Grid.Row="1" HorizontalContentAlignment="Right" Grid.Column="2"/>
+        <Label Content="Colorset:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="86" Grid.Row="2" HorizontalContentAlignment="Right" Grid.Column="2"/>
+        <ComboBox x:Name="ColorsetComboBox" Margin="10,13,136,0" VerticalAlignment="Top" Height="26" Grid.Column="3" Grid.Row="2" />
+        <Button x:Name="CopyMaterialButton" Content="Copy Material" HorizontalAlignment="Left" Margin="243,12,0,0" VerticalAlignment="Top" Width="102" Grid.Column="3" Grid.Row="1" Click="CopyMaterialButton_Click"/>
+        <Button x:Name="PasteMaterialButton" Content="Paste Material" HorizontalAlignment="Left" Margin="243,12,0,0" Grid.Row="2" VerticalAlignment="Top" Width="102" Grid.Column="3" Click="PasteMaterialButton_Click"/>
     </Grid>
 </mah:MetroWindow>

--- a/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml
+++ b/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml
@@ -33,7 +33,7 @@
         <Label x:Name="DiffuseLabel" Content="Diffuse:" Margin="10,13,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="6" RenderTransformOrigin="0.164,0.793" HorizontalContentAlignment="Right"/>
         <Label Content="Transparency:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" Grid.Row="2" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="100" HorizontalContentAlignment="Right"/>
         <ComboBox x:Name="TransparencyComboBox" Margin="10,13,10,0" VerticalAlignment="Top" Height="26" Grid.Column="1" Grid.Row="2" />
-        <Button x:Name="SaveButton" Content="Save" Grid.Column="3" Margin="0,0,10,10" Grid.Row="7" FontSize="12" HorizontalAlignment="Right" Width="135" Height="30" VerticalAlignment="Bottom"/>
+        <Button x:Name="SaveButton" Content="Save" Grid.Column="3" Margin="0,0,10,10" Grid.Row="7" FontSize="12" HorizontalAlignment="Right" Width="150" Height="30" VerticalAlignment="Bottom"/>
         <Label Content="Shader:" Margin="0,10,10,0" VerticalAlignment="Top" FontWeight="Bold" FontSize="14" Height="29" RenderTransformOrigin="0.164,0.793" HorizontalAlignment="Right" Width="63" Grid.Row="1" HorizontalContentAlignment="Right"/>
         <TextBox x:Name="NormalTextBox" Grid.Column="1" Height="26" Margin="10,17,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="4" Grid.ColumnSpan="3"/>
         <TextBox x:Name="SpecularTextBox" Grid.Column="1" Height="26" Margin="10,16,10,0" TextWrapping="Wrap" Text="Content" VerticalAlignment="Top" RenderTransformOrigin="0.802,0.545" FontWeight="Bold" Grid.Row="5" Grid.ColumnSpan="3"/>
@@ -41,7 +41,7 @@
         <Label Margin="0" Grid.ColumnSpan="4" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" FontSize="14" FontWeight="Bold" FontStyle="Italic">
             <TextBlock x:Name="MaterialPathLabel"  Text="Material Path" TextAlignment="Right" FontWeight="Bold" FontSize="14" FontStyle="Italic" />
         </Label>
-        <Button x:Name="CancelButton" Content="Cancel" Margin="0,0,151,10" Grid.Row="7" FontSize="12" Click="CancelButton_Click" HorizontalAlignment="Right" Width="135" Height="30" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Cursor="" RenderTransformOrigin="0.415,1.067"/>
+        <Button x:Name="CancelButton" Content="Cancel" Margin="10,0,0,10" Grid.Row="7" FontSize="12" Click="CancelButton_Click" HorizontalAlignment="Left" Width="150" Height="30" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Cursor="" RenderTransformOrigin="0.415,1.067"/>
         <Label Content="Texture Paths" Margin="0" Grid.Row="3" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom" Cursor="Arrow" Grid.ColumnSpan="4" FontWeight="Bold" FontStyle="Italic"/>
         <Button Content="Help" Grid.Column="3" HorizontalAlignment="Left" Margin="243,16,0,0" Grid.Row="3" VerticalAlignment="Top" Width="102" Click="HelpButton_Click"/>
         <ComboBox x:Name="PresetComboBox" Margin="10,13,136,0" VerticalAlignment="Top" Height="26" Grid.Column="3" Grid.Row="1" SelectionChanged="PresetComboBox_SelectionChanged" />
@@ -50,5 +50,6 @@
         <ComboBox x:Name="ColorsetComboBox" Margin="10,13,136,0" VerticalAlignment="Top" Height="26" Grid.Column="3" Grid.Row="2" />
         <Button x:Name="CopyMaterialButton" Content="Copy Material" HorizontalAlignment="Left" Margin="243,12,0,0" VerticalAlignment="Top" Width="102" Grid.Column="3" Grid.Row="1" Click="CopyMaterialButton_Click"/>
         <Button x:Name="PasteMaterialButton" Content="Paste Material" HorizontalAlignment="Left" Margin="243,12,0,0" Grid.Row="2" VerticalAlignment="Top" Width="102" Grid.Column="3" Click="PasteMaterialButton_Click"/>
+        <Button x:Name="DisableButton" Content="Disable/Delete" Margin="170,0,0,10" Grid.Row="7" FontSize="12" HorizontalAlignment="Left" Width="150" Height="30" VerticalAlignment="Bottom" Click="DisableButton_Click" Grid.ColumnSpan="4"/>
     </Grid>
 </mah:MetroWindow>

--- a/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml.cs
+++ b/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using xivModdingFramework.Items.Interfaces;
 using xivModdingFramework.Materials.DataContainers;
+using xivModdingFramework.Mods;
 
 namespace FFXIV_TexTools.Views.Textures
 {
@@ -73,6 +74,9 @@ namespace FFXIV_TexTools.Views.Textures
             ColorsetComboBox.SelectedValuePath = "Key";
             ColorsetComboBox.IsEnabled = false;
 
+            DisableButton.IsEnabled = false;
+            DisableButton.Visibility = Visibility.Hidden;
+
             SaveButton.Click += SaveButton_Click;
         }
 
@@ -89,17 +93,21 @@ namespace FFXIV_TexTools.Views.Textures
             return viewModel.GetMaterial();
         }
 
+        public void Close(bool result)
+        {
+            DialogResult = result;
+            Close();
+
+        }
         private async void SaveButton_Click(object sender, RoutedEventArgs e)
         {
             _material = await viewModel.SaveChanges();
-            DialogResult = true;
-            Close();
+            Close(true);
         }
 
         private void CancelButton_Click(object sender, RoutedEventArgs e)
         {
-            DialogResult = false;
-            Close();
+            Close(false);
         }
 
 
@@ -246,6 +254,11 @@ namespace FFXIV_TexTools.Views.Textures
                 _copiedMaterial.MTRLPath = _material.MTRLPath;
                 SetMaterial(_copiedMaterial, _item, _writeFile);
             }
+        }
+
+        private async void DisableButton_Click(object sender, RoutedEventArgs e)
+        {
+            await viewModel.DisableMod();
         }
     }
 }

--- a/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml.cs
+++ b/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -11,6 +12,13 @@ using xivModdingFramework.Mods;
 
 namespace FFXIV_TexTools.Views.Textures
 {
+    public enum MaterialEditorMode
+    {
+        EditSingle,
+        EditMulti,
+        NewSingle,
+        NewMulti
+    }
     /// <summary>
     /// Interaction logic for MaterialEditor.xaml
     /// </summary>
@@ -19,7 +27,7 @@ namespace FFXIV_TexTools.Views.Textures
         private MaterialEditorViewModel viewModel;
         private XivMtrl _material;
         private IItemModel _item;
-        private bool _writeFile;
+        private MaterialEditorMode _mode;
 
         public ObservableCollection<KeyValuePair<MtrlShader, string>> ShaderSource;
         public ObservableCollection<KeyValuePair<MtrlShaderPreset, string>> PresetSource;
@@ -80,12 +88,12 @@ namespace FFXIV_TexTools.Views.Textures
             SaveButton.Click += SaveButton_Click;
         }
 
-        public void SetMaterial(XivMtrl material, IItemModel item, bool writeFile = true)
+        public async Task<bool> SetMaterial(XivMtrl material, IItemModel item, MaterialEditorMode mode = MaterialEditorMode.EditSingle)
         {
             _material = material;
             _item = item;
-            _writeFile = writeFile;
-            viewModel.SetMaterial(material, item, writeFile);
+            _mode = mode;
+            return await viewModel.SetMaterial(material, item, mode);
         }
 
         public XivMtrl GetMaterial()
@@ -246,13 +254,13 @@ namespace FFXIV_TexTools.Views.Textures
             PasteMaterialButton.IsEnabled = true;
         }
 
-        private void PasteMaterialButton_Click(object sender, RoutedEventArgs e)
+        private async void PasteMaterialButton_Click(object sender, RoutedEventArgs e)
         {
             if (_copiedMaterial != null)
             {
                 // Paste the copied Material into the editor using our current path and item.
                 _copiedMaterial.MTRLPath = _material.MTRLPath;
-                SetMaterial(_copiedMaterial, _item, _writeFile);
+                await SetMaterial(_copiedMaterial, _item, _mode);
             }
         }
 

--- a/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml.cs
+++ b/FFXIV_TexTools/Views/Textures/MaterialEditorView.xaml.cs
@@ -1,7 +1,10 @@
 ﻿using FFXIV_TexTools.ViewModels;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using xivModdingFramework.Items.Interfaces;
 using xivModdingFramework.Materials.DataContainers;
 
@@ -14,6 +17,12 @@ namespace FFXIV_TexTools.Views.Textures
     {
         private MaterialEditorViewModel viewModel;
         private XivMtrl _material;
+        private IItemModel _item;
+        private bool _writeFile;
+
+        public ObservableCollection<KeyValuePair<MtrlShader, string>> ShaderSource;
+        public ObservableCollection<KeyValuePair<MtrlShaderPreset, string>> PresetSource;
+        private static XivMtrl _copiedMaterial;
         public XivMtrl Material
         {
             get
@@ -28,40 +37,26 @@ namespace FFXIV_TexTools.Views.Textures
             viewModel = new MaterialEditorViewModel(this);
 
             // Setup for the combo boxes.
-            Dictionary<MtrlShader, string> ShaderSource = new Dictionary<MtrlShader, string>();
-            ShaderSource.Add(MtrlShader.Standard, "Standard");
-            ShaderSource.Add(MtrlShader.Glass, "Glass");
-            ShaderSource.Add(MtrlShader.Skin, "Skin");
-            ShaderSource.Add(MtrlShader.Hair, "Hair");
-            ShaderSource.Add(MtrlShader.Iris, "Iris");
-            ShaderSource.Add(MtrlShader.Furniture, "Furniture");
-            ShaderSource.Add(MtrlShader.DyeableFurniture, "Dyeable Furniture");
-            ShaderSource.Add(MtrlShader.Other, "Other");
+            ShaderSource = new ObservableCollection<KeyValuePair<MtrlShader, string>>();
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.Standard, "Standard"));
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.Glass, "Glass"));
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.Skin, "Skin"));
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.Hair, "Hair"));
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.Iris, "Iris"));
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.Furniture, "Furniture"));
+            ShaderSource.Add(new KeyValuePair<MtrlShader, string>(MtrlShader.DyeableFurniture, "Dyeable Furniture"));
             ShaderComboBox.ItemsSource = ShaderSource;
             ShaderComboBox.DisplayMemberPath = "Value";
             ShaderComboBox.SelectedValuePath = "Key";
 
-            Dictionary<MtrlTextureDescriptorFormat, string> NormalSource = new Dictionary<MtrlTextureDescriptorFormat, string>();
-            NormalSource.Add(MtrlTextureDescriptorFormat.UsesColorset, "Use Colorset");
-            NormalSource.Add(MtrlTextureDescriptorFormat.NoColorset, "Do Not Use Colorset");
-            NormalComboBox.ItemsSource = NormalSource;
-            NormalComboBox.DisplayMemberPath = "Value";
-            NormalComboBox.SelectedValuePath = "Key";
 
-            Dictionary<MaterialSpecularMode, string> SpecularSource = new Dictionary<MaterialSpecularMode, string>();
-            SpecularSource.Add(MaterialSpecularMode.FullColor, "Full Color Specular");
-            SpecularSource.Add(MaterialSpecularMode.MultiMap, "Multi Map");
-            SpecularSource.Add(MaterialSpecularMode.None, "None");
-            SpecularComboBox.ItemsSource = SpecularSource;
-            SpecularComboBox.DisplayMemberPath = "Value";
-            SpecularComboBox.SelectedValuePath = "Key";
+            PresetSource = new ObservableCollection<KeyValuePair<MtrlShaderPreset, string>>();
+            PresetSource.Add(new KeyValuePair<MtrlShaderPreset, string>(MtrlShaderPreset.Default, "Default"));
+            PresetComboBox.ItemsSource = PresetSource;
+            PresetComboBox.DisplayMemberPath = "Value";
+            PresetComboBox.SelectedValuePath = "Key";
 
-            Dictionary<MaterialDiffuseMode, string> DiffuseSource = new Dictionary<MaterialDiffuseMode, string>();
-            DiffuseSource.Add(MaterialDiffuseMode.FullColor, "Full Color Diffuse");
-            DiffuseSource.Add(MaterialDiffuseMode.None, "None");
-            DiffuseComboBox.ItemsSource = DiffuseSource;
-            DiffuseComboBox.DisplayMemberPath = "Value";
-            DiffuseComboBox.SelectedValuePath = "Key";
+            PasteMaterialButton.IsEnabled = _copiedMaterial != null;
 
             Dictionary<bool, string> TransparencySource = new Dictionary<bool, string>();
             TransparencySource.Add(true, "Enabled");
@@ -70,14 +65,23 @@ namespace FFXIV_TexTools.Views.Textures
             TransparencyComboBox.DisplayMemberPath = "Value";
             TransparencyComboBox.SelectedValuePath = "Key";
 
+            Dictionary<bool, string> ColorsetSource = new Dictionary<bool, string>();
+            ColorsetSource.Add(true, "Enabled");
+            ColorsetSource.Add(false, "Disabled");
+            ColorsetComboBox.ItemsSource = ColorsetSource;
+            ColorsetComboBox.DisplayMemberPath = "Value";
+            ColorsetComboBox.SelectedValuePath = "Key";
+            ColorsetComboBox.IsEnabled = false;
+
             SaveButton.Click += SaveButton_Click;
         }
 
         public void SetMaterial(XivMtrl material, IItemModel item, bool writeFile = true)
         {
             _material = material;
+            _item = item;
+            _writeFile = writeFile;
             viewModel.SetMaterial(material, item, writeFile);
-
         }
 
         public XivMtrl GetMaterial()
@@ -98,74 +102,150 @@ namespace FFXIV_TexTools.Views.Textures
             Close();
         }
 
-        private void DiffuseComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if((MaterialDiffuseMode) DiffuseComboBox.SelectedValue == MaterialDiffuseMode.None)
-            {
-                DiffuseTextBox.IsEnabled = false;
-            } else
-            {
-                DiffuseTextBox.IsEnabled = true;
-            }
-        }
-
-        private void SpecularComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if ((MaterialSpecularMode)DiffuseComboBox.SelectedValue == MaterialSpecularMode.None)
-            {
-                SpecularTextBox.IsEnabled = false;
-            }
-            else
-            {
-                SpecularTextBox.IsEnabled = true;
-            }
-
-        }
 
         private void ShaderComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            // Changing this value around doesn't seem to actually do a ton right now,
-            // So better to leave it locked off.
-            NormalComboBox.IsEnabled = false;
-
-            if ((MtrlShader) ShaderComboBox.SelectedValue == MtrlShader.Glass)
+            if (ShaderComboBox.SelectedValue == null)
             {
-                TransparencyComboBox.SelectedValue = true;
-                TransparencyComboBox.IsEnabled = false;
-            } else if ((MtrlShader)ShaderComboBox.SelectedValue == MtrlShader.Furniture || (MtrlShader)ShaderComboBox.SelectedValue == MtrlShader.DyeableFurniture)
-            {
-                // Disable everything for furniture shader items.
-                // Haven't done enough research here yet to be able to 
-                // sanely allow them to be edited this way.
+                return;
+            }
 
-                // Furniture items also completely lack usage structs, so 
-                // how their actual maps are connected to the shader is currently
-                // totally unknown.
-                ShaderComboBox.IsEnabled = false;
-                TransparencyComboBox.IsEnabled = true;
+            var shader = (MtrlShader)ShaderComboBox.SelectedValue;
+            var presets = ShaderInfo.GetAvailablePresets(shader);
+
+            PresetSource.Clear();
+            foreach (var p in presets)
+            {
+                PresetSource.Add(new KeyValuePair<MtrlShaderPreset, string>(p, p.ToString()));
+            }
+
+            // Disable the box if the user has no choice anyways.
+            if(PresetSource.Count > 1)
+            {
+                PresetComboBox.IsEnabled = true;
+            } else
+            {
+                PresetComboBox.IsEnabled = false;
+            }
+
+
+            PresetComboBox.SelectedValue = MtrlShaderPreset.Default;
+            // Ensure the UI is updated for the new selection.
+            PresetComboBox_SelectionChanged(null, null);
+
+            if(shader == MtrlShader.Furniture || shader == MtrlShader.DyeableFurniture || shader == MtrlShader.Other )
+            {
+                // Disable all the editable options except transparency for these items.
                 NormalTextBox.IsEnabled = false;
-                SpecularComboBox.IsEnabled = false;
-                SpecularTextBox.IsEnabled = false;
-                DiffuseComboBox.IsEnabled = false;
                 DiffuseTextBox.IsEnabled = false;
+                SpecularTextBox.IsEnabled = false;
+                ColorsetComboBox.IsEnabled = false;
+                PresetComboBox.IsEnabled = false;
+            } 
+
+            if(shader == MtrlShader.Other)
+            {
+                // Disable everything.
+                TransparencyComboBox.IsEnabled = false;
+                ShaderComboBox.IsEnabled = false;
+                SaveButton.IsEnabled = false;
+                SaveButton.Visibility = Visibility.Hidden;
+            }
+        }
+
+        private void PresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if(ShaderComboBox.SelectedValue == null || PresetComboBox.SelectedValue == null)
+            {
+                return;
+            }
+
+            var shader = (MtrlShader)ShaderComboBox.SelectedValue;
+            var preset = (MtrlShaderPreset)PresetComboBox.SelectedValue;
+            var transparency = (bool)TransparencyComboBox.SelectedValue;
+
+            // Generate a fresh shader info so we can access some of the calculated fields.
+            var info = new ShaderInfo() { Shader = shader, Preset = preset, TransparencyEnabled = transparency };
+
+            ColorsetComboBox.SelectedValue = info.HasColorset;
+
+            if(info.HasMulti)
+            {
+                SpecularLabel.Content = "Multi:";
+                SpecularTextBox.IsEnabled = true;
+                SpecularLabel.Visibility = Visibility.Visible;
+                SpecularTextBox.Visibility = Visibility.Visible;
+            } else if(info.HasSpec)
+            {
+                SpecularLabel.Content = "Specular:";
+                SpecularTextBox.IsEnabled = true;
+                SpecularLabel.Visibility = Visibility.Visible;
+                SpecularTextBox.Visibility = Visibility.Visible;
+            } else
+            {
+                // This path is never actually reached currently.
+                SpecularLabel.Content = "Specular:";
+                SpecularTextBox.IsEnabled = false;
+                SpecularLabel.Visibility = Visibility.Hidden;
+                SpecularTextBox.Visibility = Visibility.Hidden;
+            }
+
+            if (info.HasDiffuse)
+            {
+                DiffuseLabel.Content = "Diffuse:";
+                DiffuseTextBox.IsEnabled = true;
+                DiffuseLabel.Visibility = Visibility.Visible;
+                DiffuseTextBox.Visibility = Visibility.Visible;
+            }
+            else if(info.HasReflection)
+            {
+                DiffuseLabel.Content = "Reflection:";
+                DiffuseTextBox.IsEnabled = true;
+                DiffuseLabel.Visibility = Visibility.Visible;
+                DiffuseTextBox.Visibility = Visibility.Visible;
 
             } else
             {
-                ShaderComboBox.IsEnabled = true;
-                TransparencyComboBox.IsEnabled = true;
-                NormalTextBox.IsEnabled = true;
-                SpecularComboBox.IsEnabled = true;
-                SpecularTextBox.IsEnabled = true;
-                DiffuseComboBox.IsEnabled = true;
-                DiffuseTextBox.IsEnabled = true;
+                DiffuseLabel.Content = "Diffuse:";
+                DiffuseTextBox.IsEnabled = false;
+                DiffuseLabel.Visibility = Visibility.Hidden;
+                DiffuseTextBox.Visibility = Visibility.Hidden;
             }
+
+            if(info.ForcedTransparency != null)
+            {
+                TransparencyComboBox.IsEnabled = false;
+                TransparencyComboBox.SelectedValue = info.ForcedTransparency;
+            } else
+            {
+                TransparencyComboBox.IsEnabled = true;
+            }
+
+
 
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+
+        private void HelpButton_Click(object sender, RoutedEventArgs e)
         {
             var help = new Views.Textures.MaterialEditorHelpView();
             help.ShowDialog();
+        }
+
+        private void CopyMaterialButton_Click(object sender, RoutedEventArgs e)
+        {
+            _copiedMaterial = _material;
+            PasteMaterialButton.IsEnabled = true;
+        }
+
+        private void PasteMaterialButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_copiedMaterial != null)
+            {
+                // Paste the copied Material into the editor using our current path and item.
+                _copiedMaterial.MTRLPath = _material.MTRLPath;
+                SetMaterial(_copiedMaterial, _item, _writeFile);
+            }
         }
     }
 }

--- a/FFXIV_TexTools/Views/Textures/MoreTextureOptionsView.xaml
+++ b/FFXIV_TexTools/Views/Textures/MoreTextureOptionsView.xaml
@@ -9,7 +9,8 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <UniformGrid Rows="1" VerticalAlignment="Center">
-        <Button Content="ADD NEW MATERIAL" VerticalAlignment="Center" Margin="0,10,10,10" Command="{Binding AddNewTexturePartButton}" IsEnabled="{Binding AddNewTexturePartEnabled}" HorizontalAlignment="Right" Width="380"/>
-        <Button Content="{Binding Source={x:Static resx:UIStrings.Material_Editor}}" VerticalAlignment="Center" Margin="10" Command="{Binding OpenMaterialEditorButton}" IsEnabled="{Binding MaterialEditorEnabled}" />
+        <Button Content="ADD NEW MATERIAL" Margin="10" Command="{Binding AddNewTexturePartButton}" IsEnabled="{Binding AddNewTexturePartEnabled}"/>
+        <Button Content="EDIT ALL MATERIAL VARIANTS" Margin="10" Command="{Binding OpenSharedMaterialEditorButton}" IsEnabled="{Binding AddNewTexturePartEnabled}"/>
+        <Button Content="{Binding Source={x:Static resx:UIStrings.Material_Editor}}" Margin="10" Command="{Binding OpenMaterialEditorButton}" IsEnabled="{Binding MaterialEditorEnabled}" />
     </UniformGrid>
 </UserControl>

--- a/FFXIV_TexTools/Views/Textures/MoreTextureOptionsView.xaml
+++ b/FFXIV_TexTools/Views/Textures/MoreTextureOptionsView.xaml
@@ -11,6 +11,6 @@
     <UniformGrid Rows="1" VerticalAlignment="Center">
         <Button Content="ADD NEW MATERIAL" Margin="10" Command="{Binding AddNewTexturePartButton}" IsEnabled="{Binding AddNewTexturePartEnabled}"/>
         <Button Content="EDIT ALL MATERIAL VARIANTS" Margin="10" Command="{Binding OpenSharedMaterialEditorButton}" IsEnabled="{Binding AddNewTexturePartEnabled}"/>
-        <Button Content="{Binding Source={x:Static resx:UIStrings.Material_Editor}}" Margin="10" Command="{Binding OpenMaterialEditorButton}" IsEnabled="{Binding MaterialEditorEnabled}" />
+        <Button Content="EDIT MATERIAL" Margin="10" Command="{Binding OpenMaterialEditorButton}" IsEnabled="{Binding MaterialEditorEnabled}" IsCancel="True" />
     </UniformGrid>
 </UserControl>


### PR DESCRIPTION
- Significant Changes to the Material Editor interface to make it easier to use.
  - Now Preset driven.
  - Now displays status during long operations (save/etc.)
  - Can now copy/paste entire materials via the Editor.
  - Can now edit all Variant materials at the same time.
  - Can now disable/delete material edits directly from the Material Editor
  - Material Editor now re-selects the material you were just editing/just created after saving.
  - Skin, Hair, and Iris Shaders now work appropriately on all gear, with presets.
  - Glass and Standard Shader have had presets updated to help avoid ending up in broken states.

- Other
  - Fixed a crash bug when switching between items too fast in the main menu.
  - Fixed an issue with modpacks with the same file in them redundantly creating redundant mod list entries on import.